### PR TITLE
Fix mail header parsing for `To`

### DIFF
--- a/françoise/mail.py
+++ b/françoise/mail.py
@@ -1,4 +1,25 @@
+import re
+from typing import Optional
+
 import requests
+
+
+def parse_to_header(headers: str) -> Optional[str]:
+    match = re.search('\\["To",([^\\]]*)\\]', headers)
+    if not match:
+        return None
+    return match.group(1)
+
+
+def parse_conversation_id_from_headers(headers: str) -> Optional[int]:
+    to = parse_to_header(headers)
+    if not to:
+        return None
+    match = re.search('\\.(\\d+)[^\\s]*\\s<', to)
+    if not match:
+        return None
+    return int(match.group(1))
+
 
 def send_mail(url: str, **kwargs):
     if not url:

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -1,0 +1,19 @@
+import unittest
+
+from françoise.mail import parse_to_header, parse_conversation_id_from_headers
+
+
+class TestMail(unittest.TestCase):
+    def test_parse_to_header(self):
+        headers = '[["To","\"Boku.2\" <foo@bar.com>"]]'
+        to = parse_to_header(headers)
+        self.assertEqual(to, '"\"Boku.2\" <foo@bar.com>"')
+
+    def test_parse_conversation_id_from_headers(self):
+        headers = '[["To","\"Boku.2\" <foo@bar.com>"]]'
+        conversation_id = parse_conversation_id_from_headers(headers)
+        self.assertEqual(conversation_id, 2)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
These changes fix the mail header parsing for `To`, as it the previous regular expression was too specific and did not account for escaped characters (notably, `\"`). Add tests for confidence.