### PR TITLE
Task 1 — Create the core module (#9)

### DIFF
--- a/françoise/core.py
+++ b/françoise/core.py
@@ -1,0 +1,31 @@
+import os
+
+from .chat import chat, get_prompt_message_from_conversation, message_tuple_to_dict
+from .db import open_db
+
+
+def handle_inbound(conversation_id: int, text: str) -> str:
+    """Generate a reply for an inbound message on a conversation.
+
+    Reads the conversation, builds the prompt, persists the user message,
+    calls the LLM, persists the reply, and returns the reply text. This is
+    medium-agnostic: it knows nothing about email or HTTP.
+    """
+    database_url = os.environ.get('DATABASE_URL', 'data.db')
+    llm_api_chat_url = os.environ.get('LLM_API_CHAT_URL', 'http://localhost:11434/api/chat')
+
+    with open_db(database_url) as db:
+        result = db.get_conversation(conversation_id)
+        if not result:
+            raise Exception('conversation with `id` %d does not exist' % conversation_id)
+
+        conversation = db.conversation_to_dict(result)
+
+        prompt = get_prompt_message_from_conversation(conversation)
+        db.add_user_message(conversation_id, text)
+        messages = db.get_messages_by_conversation(conversation_id)
+        message_objects = list(map(message_tuple_to_dict, [prompt] + messages))
+        reply = chat(message_objects, model=conversation.get('model'), url=llm_api_chat_url)
+        db.add_assistant_message(conversation_id, reply)
+
+    return reply

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,38 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from françoise.core import handle_inbound
+from françoise.db import open_db
+
+
+class TestCore(unittest.TestCase):
+    def setUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix='.db')
+        os.close(fd)
+        os.environ['DATABASE_URL'] = self.db_path
+
+        with open_db(self.db_path) as db:
+            db.create_schema()
+            user = db.create_user('Alice', 'alice@example.com', 'salt', 'password')
+            agent = db.create_agent('Boku', 'French', 'A1', 'You are {agent_name}.')
+            self.conversation = db.create_conversation(
+                user_id=user[0],
+                agent_id=agent[0],
+                proficiency='A1',
+                model='test-model')
+
+    def tearDown(self):
+        os.environ.pop('DATABASE_URL', None)
+        os.remove(self.db_path)
+
+    @patch('françoise.core.chat', return_value='Bonjour !')
+    def test_handle_inbound_returns_reply_text(self, mock_chat):
+        reply = handle_inbound(self.conversation[0], 'Hello')
+        self.assertEqual(reply, 'Bonjour !')
+        mock_chat.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #9

## What changed
Adds `françoise/core.py` with `handle_inbound(conversation_id, text) -> str`, holding the medium-agnostic reply logic: read the conversation from the DB, build the prompt, persist the user message, call the LLM, persist the reply, and return the reply text.

- No FastAPI / HTTP imports in `core.py` (config read from `os.environ`, matching `app.py` defaults).
- Adds `tests/test_core.py`: seeds a temp SQLite conversation, mocks the LLM `chat` call, and asserts `handle_inbound` returns the reply text.

## Scope
Per the issue, this is Task 1 only. Full extraction of `chat_and_reply` in `app.py` to call `handle_inbound` is Task 2 (#10) and is intentionally not done here to keep the diff minimal.

## Test plan
- `handle_inbound` imported, called with a test conversation, returns the mocked reply text — passing.

_Note: the repo's `fastapi[standard]` pulls a transitive `rignore` Rust dep that fails to build in this environment; the new test was validated in a scratch venv with `requests` only, since `core.py` needs no FastAPI._