### PR TITLE
Connect the Mailgun route to the core

### DIFF
--- a/françoise/app.py
+++ b/françoise/app.py
@@ -4,7 +4,7 @@ from typing import Annotated, Optional
 
 from fastapi import BackgroundTasks, FastAPI, Form, Response, status
 
-from .chat import chat, get_prompt_message_from_conversation, message_tuple_to_dict
+from .core import handle_inbound
 from .db import open_db
 from .mail import parse_conversation_id_from_headers, send_mail
 
@@ -49,12 +49,7 @@ def App(**kwargs):
             if sender not in user_email:
                 raise Exception('invalid user email `%s` for conversation %d' % (user_email, conversation_id))
 
-            prompt = get_prompt_message_from_conversation(conversation)
-            db.add_user_message(conversation_id, message)
-            messages = db.get_messages_by_conversation(conversation_id)
-            message_objects = list(map(message_tuple_to_dict, [prompt] + messages))
-            response = chat(message_objects, model=conversation.get('model'), url=LLM_API_CHAT_URL)
-            db.add_assistant_message(conversation_id, response)
+        response = handle_inbound(conversation_id, message)
 
         data = {
             "from": "%s.%d <%s>" % (conversation.get('agent_name'), conversation_id, MAILGUN_API_SENDER),

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,57 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from françoise.app import App
+from françoise.db import open_db
+
+
+class TestMailgunRoute(unittest.TestCase):
+    def setUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix='.db')
+        os.close(fd)
+
+        with open_db(self.db_path) as db:
+            db.create_schema()
+            user = db.create_user('Alice', 'alice@example.com', 'salt', 'password')
+            agent = db.create_agent('Boku', 'French', 'A1', 'You are {agent_name}.')
+            self.conversation = db.create_conversation(
+                user_id=user[0],
+                agent_id=agent[0],
+                proficiency='A1',
+                model='test-model')
+
+        self.app = App(
+            DATABASE_URL=self.db_path,
+            MAILGUN_API_KEY='key',
+            MAILGUN_API_SENDER='boku@example.com',
+            MAILGUN_API_URL='https://api.example.com')
+        self.client = TestClient(self.app)
+
+    def tearDown(self):
+        os.remove(self.db_path)
+
+    def test_mailgun_calls_core_and_sends_reply(self):
+        conversation_id = self.conversation[0]
+        headers = '[["To","\"Boku.%d\" <boku@example.com>"]]' % conversation_id
+
+        with patch('françoise.app.handle_inbound', return_value='Bonjour !') as mock_core, \
+                patch('françoise.app.send_mail') as mock_send:
+            response = self.client.post('/mailgun', data={
+                'message-headers': headers,
+                'body-plain': 'Hello',
+                'sender': 'alice@example.com',
+                'subject': 'Salut'})
+
+        self.assertEqual(response.status_code, 200)
+        mock_core.assert_called_once_with(conversation_id, 'Hello')
+        mock_send.assert_called_once()
+        _, kwargs = mock_send.call_args
+        self.assertEqual(kwargs['data']['text'], 'Bonjour !')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Call handle_inbound from chat_and_reply for the core LLM logic and send
the returned text via the Mailgun adapter, removing the duplicated logic.

Closes #11
