### PR TITLE
Task 6: bootstrap schema via Alembic migration

### DIFF
--- a/françoise/db.py
+++ b/françoise/db.py
@@ -61,28 +61,9 @@ for table in tables:
     tables_by_name[table[0]] = table
 
 
-def table_definition_to_create_statement(definition: tuple) -> str:
-    columns = ', '.join(list(map(lambda col: ' '.join(col), definition[1])))
-
-    constraints = ''
-    if len(definition) == 3:
-        constraints = ', %s' % (', '.join(definition[2]),)
-
-    return 'CREATE TABLE IF NOT EXISTS {table_name} ({columns}{constraints});'.format(
-            table_name=definition[0],
-            columns=columns,
-            constraints=constraints)
-
-
 class Database:
     def __init__(self, connection):
         self.connection = connection
-
-    def create_schema(self):
-        with self.connection:
-            # NOTE it didn't look like we could create tables in one go
-            for sql in list(map(table_definition_to_create_statement, tables)):
-                self.connection.execute(sql)
 
     def delete_schema(self):
         for table_name in tables_by_name.keys():

--- a/françoise/migrate.py
+++ b/françoise/migrate.py
@@ -1,0 +1,13 @@
+import os
+
+from alembic import command
+from alembic.config import Config
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def upgrade_to_head(database_url: str) -> None:
+    """Bring a database up to the latest migration."""
+    os.environ['DATABASE_URL'] = database_url
+    config = Config(os.path.join(ROOT, 'alembic.ini'))
+    command.upgrade(config, 'head')

--- a/scripts/db-init.py
+++ b/scripts/db-init.py
@@ -10,7 +10,7 @@ if __name__ == '__main__' and __package__ is None:
     sys.path.append(PARENT_DIR)
 
 from dotenv import load_dotenv
-from françoise.db import open_db
+from françoise.migrate import upgrade_to_head
 
 load_dotenv()
 
@@ -21,5 +21,4 @@ parser.add_argument("-db", "--database", type=str, default=os.environ.get('DATAB
 
 args = parser.parse_args()
 
-with open_db(args.database) as db:
-    db.create_schema()
+upgrade_to_head(args.database)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -7,6 +7,7 @@ from fastapi.testclient import TestClient
 
 from françoise.app import App
 from françoise.db import open_db
+from françoise.migrate import upgrade_to_head
 
 
 class TestMailgunRoute(unittest.TestCase):
@@ -14,8 +15,8 @@ class TestMailgunRoute(unittest.TestCase):
         fd, self.db_path = tempfile.mkstemp(suffix='.db')
         os.close(fd)
 
+        upgrade_to_head(self.db_path)
         with open_db(self.db_path) as db:
-            db.create_schema()
             user = db.create_user('Alice', 'alice@example.com', 'salt', 'password')
             agent = db.create_agent('Boku', 'French', 'A1', 'You are {agent_name}.')
             self.conversation = db.create_conversation(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from françoise.core import handle_inbound
 from françoise.db import open_db
+from françoise.migrate import upgrade_to_head
 
 
 class TestCore(unittest.TestCase):
@@ -13,8 +14,8 @@ class TestCore(unittest.TestCase):
         os.close(fd)
         os.environ['DATABASE_URL'] = self.db_path
 
+        upgrade_to_head(self.db_path)
         with open_db(self.db_path) as db:
-            db.create_schema()
             user = db.create_user('Alice', 'alice@example.com', 'salt', 'password')
             agent = db.create_agent('Boku', 'French', 'A1', 'You are {agent_name}.')
             self.conversation = db.create_conversation(

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -8,31 +8,44 @@ from alembic.config import Config
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
+SCHEMA_TABLES = {'users', 'agents', 'conversations', 'messages'}
+
+
+def existing_tables(db_path):
+    connection = sqlite3.connect(db_path)
+    try:
+        rows = connection.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table'"
+        ).fetchall()
+    finally:
+        connection.close()
+    return {row[0] for row in rows}
+
 
 class TestMigrations(unittest.TestCase):
     def setUp(self):
         fd, self.db_path = tempfile.mkstemp(suffix='.db')
         os.close(fd)
         os.environ['DATABASE_URL'] = self.db_path
+        self.config = Config(os.path.join(ROOT, 'alembic.ini'))
+        self.config.set_main_option('script_location', os.path.join(ROOT, 'migrations'))
 
     def tearDown(self):
         os.environ.pop('DATABASE_URL', None)
         os.remove(self.db_path)
 
     def test_upgrade_head_creates_version_table(self):
-        config = Config(os.path.join(ROOT, 'alembic.ini'))
-        config.set_main_option('script_location', os.path.join(ROOT, 'migrations'))
-        command.upgrade(config, 'head')
+        command.upgrade(self.config, 'head')
+        self.assertIn('alembic_version', existing_tables(self.db_path))
 
-        connection = sqlite3.connect(self.db_path)
-        try:
-            row = connection.execute(
-                "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'alembic_version'"
-            ).fetchone()
-        finally:
-            connection.close()
+    def test_upgrade_creates_schema_tables(self):
+        command.upgrade(self.config, 'head')
+        self.assertTrue(SCHEMA_TABLES.issubset(existing_tables(self.db_path)))
 
-        self.assertIsNotNone(row)
+    def test_downgrade_drops_schema_tables(self):
+        command.upgrade(self.config, 'head')
+        command.downgrade(self.config, 'base')
+        self.assertEqual(SCHEMA_TABLES & existing_tables(self.db_path), set())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Remove the create_schema bootstrap from db.py and route callers
(db-init script, tests) through the initial Alembic migration. Add
migration coverage that the upgrade creates the four tables and the
downgrade drops them.
