### PR TITLE
Task 7: Add accounts table

### DIFF
--- a/françoise/db.py
+++ b/françoise/db.py
@@ -4,6 +4,15 @@ import sqlite3
 
 tables = [
     (
+        'accounts',
+        [
+            ('id', 'INTEGER PRIMARY KEY AUTOINCREMENT'),
+            ('name', 'TEXT NOT NULL'),
+            ('created_at', 'TEXT NOT NULL')
+        ]
+    ),
+
+    (
         'users',
          [
              ('id', 'INTEGER PRIMARY KEY AUTOINCREMENT'),
@@ -91,6 +100,18 @@ class Database:
             row = cursor.fetchone()
 
         return row
+
+    def create_account(self, name: str) -> tuple:
+        now = datetime.now(timezone.utc)
+        return self.table_insert(
+                'accounts',
+                name=name,
+                created_at=now.isoformat())
+
+    def get_account(self, id: int):
+        res = self.connection.execute(
+            "SELECT id, name, created_at FROM accounts WHERE id = ?", (id,))
+        return res.fetchone()
 
     def create_agent(
             self,

--- a/migrations/versions/a1b2c3d4e5f6_add_accounts_table.py
+++ b/migrations/versions/a1b2c3d4e5f6_add_accounts_table.py
@@ -1,0 +1,34 @@
+"""add accounts table
+
+Revision ID: a1b2c3d4e5f6
+Revises: 4bec47424dbc
+Create Date: 2026-08-09 03:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a1b2c3d4e5f6'
+down_revision: Union[str, Sequence[str], None] = '4bec47424dbc'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS accounts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        );
+    """)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.execute("DROP TABLE IF EXISTS accounts;")

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -6,9 +6,11 @@ import unittest
 from alembic import command
 from alembic.config import Config
 
+from françoise.db import open_db
+
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-SCHEMA_TABLES = {'users', 'agents', 'conversations', 'messages'}
+SCHEMA_TABLES = {'accounts', 'users', 'agents', 'conversations', 'messages'}
 
 
 def existing_tables(db_path):
@@ -46,6 +48,15 @@ class TestMigrations(unittest.TestCase):
         command.upgrade(self.config, 'head')
         command.downgrade(self.config, 'base')
         self.assertEqual(SCHEMA_TABLES & existing_tables(self.db_path), set())
+
+    def test_insert_and_read_account(self):
+        command.upgrade(self.config, 'head')
+        with open_db(self.db_path) as db:
+            created = db.create_account('Acme')
+            read = db.get_account(created[0])
+        self.assertEqual(read[0], created[0])
+        self.assertEqual(read[1], 'Acme')
+        self.assertTrue(read[2])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add migration creating accounts (id, name, created_at) and
create_account/get_account functions in db.py. Closes #15.
