### PR TITLE
Task 10: scope db queries by account

### DIFF
--- a/françoise/app.py
+++ b/françoise/app.py
@@ -37,7 +37,12 @@ def App(**kwargs):
         if not conversation_id:
             raise Exception('unspecified conversation `id` in %s' % (headers,))
 
-        with open_db(DATABASE_URL) as db:
+        with open_db(DATABASE_URL) as resolver:
+            account_id = resolver.get_account_id_for_conversation(conversation_id)
+        if account_id is None:
+            raise Exception('conversation with `id` %d does not exist' % conversation_id)
+
+        with open_db(DATABASE_URL, account_id=account_id) as db:
             result = db.get_conversation(conversation_id)
 
             if not result:

--- a/françoise/core.py
+++ b/françoise/core.py
@@ -14,7 +14,12 @@ def handle_inbound(conversation_id: int, text: str) -> str:
     database_url = os.environ.get('DATABASE_URL', 'data.db')
     llm_api_chat_url = os.environ.get('LLM_API_CHAT_URL', 'http://localhost:11434/api/chat')
 
-    with open_db(database_url) as db:
+    with open_db(database_url) as resolver:
+        account_id = resolver.get_account_id_for_conversation(conversation_id)
+    if account_id is None:
+        raise Exception('conversation with `id` %d does not exist' % conversation_id)
+
+    with open_db(database_url, account_id=account_id) as db:
         result = db.get_conversation(conversation_id)
         if not result:
             raise Exception('conversation with `id` %d does not exist' % conversation_id)

--- a/françoise/db.py
+++ b/françoise/db.py
@@ -70,9 +70,20 @@ for table in tables:
     tables_by_name[table[0]] = table
 
 
+# Tables scoped by a tenant account. `accounts` is the tenant itself and
+# `messages` is scoped transitively through its conversation.
+account_scoped_tables = ('users', 'agents', 'conversations')
+
+
 class Database:
-    def __init__(self, connection):
+    def __init__(self, connection, account_id=None):
         self.connection = connection
+        self.account_id = account_id
+
+    def require_account(self) -> int:
+        if self.account_id is None:
+            raise Exception('query requires an `account_id`')
+        return self.account_id
 
     def delete_schema(self):
         for table_name in tables_by_name.keys():
@@ -82,6 +93,9 @@ class Database:
         table = tables_by_name.get(table_name)
         if not table:
             raise Exception('table with name `%s` is unspecified' % table_name)
+
+        if table_name in account_scoped_tables:
+            kwargs['account_id'] = self.require_account()
 
         columns = []
         params = []
@@ -112,6 +126,16 @@ class Database:
         res = self.connection.execute(
             "SELECT id, name, created_at FROM accounts WHERE id = ?", (id,))
         return res.fetchone()
+
+    def get_account_id_for_conversation(self, conversation_id: int):
+        # Unscoped resolver: identifies which tenant owns a conversation so a
+        # caller can open a scoped Database. This is the one entry point that
+        # runs before an account is known.
+        res = self.connection.execute(
+            "SELECT account_id FROM conversations WHERE id = ?",
+            (conversation_id,))
+        row = res.fetchone()
+        return row[0] if row else None
 
     def create_agent(
             self,
@@ -153,6 +177,11 @@ class Database:
                 model=model)
 
     def create_message(self, conversation_id: int, role: str, content: str):
+        # messages are scoped through their conversation's account
+        if not self.get_conversation(conversation_id):
+            raise Exception(
+                'conversation with `id` %d does not exist for account'
+                % conversation_id)
         now = datetime.now(timezone.utc)
         return self.table_insert(
                 'messages',
@@ -187,7 +216,8 @@ class Database:
             JOIN agents agent
             ON conversation.agent_id = agent.id
             WHERE conversation.id = ?
-        """, (id,))
+            AND conversation.account_id = ?
+        """, (id, self.require_account()))
         return res.fetchone()
 
     def conversation_to_dict(self, conversation: tuple) -> dict[str, str]:
@@ -205,7 +235,13 @@ class Database:
                     conversation))
 
     def get_messages_by_conversation(self, conversation_id: int):
-        res = self.connection.execute("SELECT role, content FROM messages WHERE conversation_id = ?", (conversation_id,))
+        res = self.connection.execute("""
+            SELECT role, content FROM messages
+            WHERE conversation_id = ?
+            AND conversation_id IN (
+                SELECT id FROM conversations WHERE account_id = ?
+            )
+        """, (conversation_id, self.require_account()))
         return res.fetchall()
 
     def table_delete(self, table_name: str):
@@ -222,9 +258,9 @@ class Database:
 
 
 @contextmanager
-def open_db(url: str):
+def open_db(url: str, account_id=None):
     connection = sqlite3.connect(url)
     try:
-        yield Database(connection)
+        yield Database(connection, account_id)
     finally:
         connection.close()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -17,6 +17,8 @@ class TestMailgunRoute(unittest.TestCase):
 
         upgrade_to_head(self.db_path)
         with open_db(self.db_path) as db:
+            account = db.create_account('Acme')
+        with open_db(self.db_path, account_id=account[0]) as db:
             user = db.create_user('Alice', 'alice@example.com', 'salt', 'password')
             agent = db.create_agent('Boku', 'French', 'A1', 'You are {agent_name}.')
             self.conversation = db.create_conversation(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -16,6 +16,9 @@ class TestCore(unittest.TestCase):
 
         upgrade_to_head(self.db_path)
         with open_db(self.db_path) as db:
+            account = db.create_account('Acme')
+        self.account_id = account[0]
+        with open_db(self.db_path, account_id=self.account_id) as db:
             user = db.create_user('Alice', 'alice@example.com', 'salt', 'password')
             agent = db.create_agent('Boku', 'French', 'A1', 'You are {agent_name}.')
             self.conversation = db.create_conversation(
@@ -39,7 +42,7 @@ class TestCore(unittest.TestCase):
         conversation_id = self.conversation[0]
         handle_inbound(conversation_id, 'Hello')
 
-        with open_db(self.db_path) as db:
+        with open_db(self.db_path, account_id=self.account_id) as db:
             messages = db.get_messages_by_conversation(conversation_id)
 
         self.assertIn(('user', 'Hello'), messages)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,52 @@
+import os
+import tempfile
+import unittest
+
+from françoise.db import open_db
+from françoise.migrate import upgrade_to_head
+
+
+class TestAccountScope(unittest.TestCase):
+    def setUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix='.db')
+        os.close(fd)
+        upgrade_to_head(self.db_path)
+
+        # Seed two accounts, each with its own conversation.
+        with open_db(self.db_path) as db:
+            self.account_one = db.create_account('One')[0]
+            self.account_two = db.create_account('Two')[0]
+
+        with open_db(self.db_path, account_id=self.account_one) as db:
+            user = db.create_user('Alice', 'alice@example.com', 'salt', 'pw')
+            agent = db.create_agent('Boku', 'French', 'A1', 'You are {agent_name}.')
+            self.conversation_one = db.create_conversation(
+                user_id=user[0], agent_id=agent[0],
+                proficiency='A1', model='m')[0]
+
+        with open_db(self.db_path, account_id=self.account_two) as db:
+            user = db.create_user('Bob', 'bob@example.com', 'salt', 'pw')
+            agent = db.create_agent('Kimi', 'French', 'A1', 'You are {agent_name}.')
+            self.conversation_two = db.create_conversation(
+                user_id=user[0], agent_id=agent[0],
+                proficiency='A1', model='m')[0]
+
+    def tearDown(self):
+        os.remove(self.db_path)
+
+    def test_read_excludes_other_account(self):
+        with open_db(self.db_path, account_id=self.account_one) as db:
+            self.assertIsNotNone(db.get_conversation(self.conversation_one))
+            # account two's conversation is invisible to account one
+            self.assertIsNone(db.get_conversation(self.conversation_two))
+
+    def test_query_without_account_raises(self):
+        with open_db(self.db_path) as db:
+            with self.assertRaises(Exception):
+                db.get_conversation(self.conversation_one)
+            with self.assertRaises(Exception):
+                db.create_user('Eve', 'eve@example.com', 'salt', 'pw')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Bind an account_id to Database and require it on every read and write.
Inserts to users/agents/conversations carry account_id; reads filter by
it; messages scope through their conversation. Callers resolve a
conversation's account before opening a scoped connection.

Closes #18
