### PR TITLE
Hash user passwords with argon2id (#19)

### DIFF
--- a/françoise/db.py
+++ b/françoise/db.py
@@ -18,8 +18,7 @@ tables = [
              ('id', 'INTEGER PRIMARY KEY AUTOINCREMENT'),
              ('name', 'TEXT NOT NULL'),
              ('email', 'TEXT UNIQUE'),
-             ('salt', 'TEXT NOT NULL'),
-             ('password', 'TEXT NOT NULL')
+             ('password_hash', 'TEXT NOT NULL')
          ]
     ),
 
@@ -154,14 +153,12 @@ class Database:
             self,
             name: str,
             email: str,
-            salt: str,
-            password: str) -> tuple:
+            password_hash: str) -> tuple:
         return self.table_insert(
                 'users',
                 name=name,
                 email=email,
-                salt=salt,
-                password=password)
+                password_hash=password_hash)
 
     def create_conversation(
             self,

--- a/migrations/versions/d4e5f6a7b8c9_use_password_hash.py
+++ b/migrations/versions/d4e5f6a7b8c9_use_password_hash.py
@@ -1,0 +1,32 @@
+"""replace user salt and password with a single password_hash
+
+Revision ID: d4e5f6a7b8c9
+Revises: c3d4e5f6a7b8
+Create Date: 2026-08-09 06:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'd4e5f6a7b8c9'
+down_revision: Union[str, Sequence[str], None] = 'c3d4e5f6a7b8'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.execute("ALTER TABLE users ADD COLUMN password_hash TEXT NOT NULL DEFAULT '';")
+    op.execute("ALTER TABLE users DROP COLUMN salt;")
+    op.execute("ALTER TABLE users DROP COLUMN password;")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.execute("ALTER TABLE users ADD COLUMN salt TEXT NOT NULL DEFAULT '';")
+    op.execute("ALTER TABLE users ADD COLUMN password TEXT NOT NULL DEFAULT '';")
+    op.execute("ALTER TABLE users DROP COLUMN password_hash;")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 requires-python = ">=3.14"
 dependencies = [
     "alembic==1.19.1",
-    "bcrypt==5.0.0",
+    "argon2-cffi==25.1.0",
     "fastapi[standard]==0.120.2",
     "python-dotenv==1.2.1",
     "requests==2.32.5",

--- a/scripts/user-onboard.py
+++ b/scripts/user-onboard.py
@@ -9,7 +9,7 @@ if __name__ == '__main__' and __package__ is None:
     PARENT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     sys.path.append(PARENT_DIR)
 
-import bcrypt
+from argon2 import PasswordHasher
 from dotenv import load_dotenv
 from françoise.db import open_db
 
@@ -28,16 +28,14 @@ parser.add_argument("-db", "--database", type=str, default=os.environ.get('DATAB
 
 args = parser.parse_args()
 
-salt = bcrypt.gensalt()
-password = args.password.encode('utf-8')
-hashed_password = bcrypt.hashpw(password, salt)
+# PasswordHasher defaults to the argon2id variant.
+password_hash = PasswordHasher().hash(args.password)
 
 with open_db(args.database) as db:
     user = db.create_user(
             name=args.name,
             email=args.email,
-            salt=salt,
-            password=hashed_password)
+            password_hash=password_hash)
 
     print('create user with id `%d`' % (user[0],))
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -19,7 +19,7 @@ class TestMailgunRoute(unittest.TestCase):
         with open_db(self.db_path) as db:
             account = db.create_account('Acme')
         with open_db(self.db_path, account_id=account[0]) as db:
-            user = db.create_user('Alice', 'alice@example.com', 'salt', 'password')
+            user = db.create_user('Alice', 'alice@example.com', 'hash')
             agent = db.create_agent('Boku', 'French', 'A1', 'You are {agent_name}.')
             self.conversation = db.create_conversation(
                 user_id=user[0],

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -19,7 +19,7 @@ class TestCore(unittest.TestCase):
             account = db.create_account('Acme')
         self.account_id = account[0]
         with open_db(self.db_path, account_id=self.account_id) as db:
-            user = db.create_user('Alice', 'alice@example.com', 'salt', 'password')
+            user = db.create_user('Alice', 'alice@example.com', 'hash')
             agent = db.create_agent('Boku', 'French', 'A1', 'You are {agent_name}.')
             self.conversation = db.create_conversation(
                 user_id=user[0],

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -18,14 +18,14 @@ class TestAccountScope(unittest.TestCase):
             self.account_two = db.create_account('Two')[0]
 
         with open_db(self.db_path, account_id=self.account_one) as db:
-            user = db.create_user('Alice', 'alice@example.com', 'salt', 'pw')
+            user = db.create_user('Alice', 'alice@example.com', 'hash')
             agent = db.create_agent('Boku', 'French', 'A1', 'You are {agent_name}.')
             self.conversation_one = db.create_conversation(
                 user_id=user[0], agent_id=agent[0],
                 proficiency='A1', model='m')[0]
 
         with open_db(self.db_path, account_id=self.account_two) as db:
-            user = db.create_user('Bob', 'bob@example.com', 'salt', 'pw')
+            user = db.create_user('Bob', 'bob@example.com', 'hash')
             agent = db.create_agent('Kimi', 'French', 'A1', 'You are {agent_name}.')
             self.conversation_two = db.create_conversation(
                 user_id=user[0], agent_id=agent[0],
@@ -45,7 +45,7 @@ class TestAccountScope(unittest.TestCase):
             with self.assertRaises(Exception):
                 db.get_conversation(self.conversation_one)
             with self.assertRaises(Exception):
-                db.create_user('Eve', 'eve@example.com', 'salt', 'pw')
+                db.create_user('Eve', 'eve@example.com', 'hash')
 
 
 if __name__ == '__main__':

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -67,7 +67,7 @@ class TestMigrations(unittest.TestCase):
                 "INSERT INTO accounts (name, created_at) VALUES ('Acme', 'now') RETURNING id"
             ).fetchone()[0]
             for table, columns in (
-                ('users', "name, email, salt, password, account_id"),
+                ('users', "name, email, password_hash, account_id"),
                 ('agents', "name, language, proficiency, prompt, account_id"),
             ):
                 values = ['x'] * (len(columns.split(',')) - 1)
@@ -93,8 +93,8 @@ class TestMigrations(unittest.TestCase):
         connection = sqlite3.connect(self.db_path)
         try:
             user_id = connection.execute(
-                "INSERT INTO users (name, email, salt, password) "
-                "VALUES ('u', 'u@x', 's', 'p') RETURNING id"
+                "INSERT INTO users (name, email, password_hash) "
+                "VALUES ('u', 'u@x', 'p') RETURNING id"
             ).fetchone()[0]
             agent_id = connection.execute(
                 "INSERT INTO agents (name, language, proficiency, prompt) "
@@ -111,6 +111,24 @@ class TestMigrations(unittest.TestCase):
             connection.close()
         self.assertEqual(user_iri, 'urn:francoise:user:%d' % user_id)
         self.assertEqual(agent_iri, 'urn:francoise:agent:%d' % agent_id)
+
+    def test_onboarded_user_stores_argon2id_hash(self):
+        from argon2 import PasswordHasher
+
+        command.upgrade(self.config, 'head')
+        password_hash = PasswordHasher().hash('hunter2')
+        with open_db(self.db_path) as db:
+            account_id = db.create_account('Acme')[0]
+        with open_db(self.db_path, account_id=account_id) as db:
+            db.create_user('U', 'u@x', password_hash)
+        connection = sqlite3.connect(self.db_path)
+        try:
+            stored = connection.execute(
+                "SELECT password_hash FROM users WHERE email = 'u@x'"
+            ).fetchone()[0]
+        finally:
+            connection.close()
+        self.assertTrue(stored.startswith('$argon2id$'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Replace the users table's salt and password columns with a single
password_hash, and hash onboarding passwords with argon2id via
argon2-cffi (replacing bcrypt).
