### PR TITLE
Add sessions table and session CRUD functions

### DIFF
--- a/françoise/db.py
+++ b/françoise/db.py
@@ -61,6 +61,18 @@ tables = [
         [
             'FOREIGN KEY(conversation_id) REFERENCES conversations(id)'
         ]
+    ),
+
+    (
+        'sessions',
+        [
+            ('id', 'TEXT PRIMARY KEY'),
+            ('user_id', 'INTEGER NOT NULL'),
+            ('expires_at', 'TEXT NOT NULL')
+        ],
+        [
+            'FOREIGN KEY(user_id) REFERENCES users(id)'
+        ]
     )
 ]
 
@@ -159,6 +171,27 @@ class Database:
                 name=name,
                 email=email,
                 password_hash=password_hash)
+
+    def create_session(
+            self,
+            id: str,
+            user_id: int,
+            expires_at: str) -> tuple:
+        return self.table_insert(
+                'sessions',
+                id=id,
+                user_id=user_id,
+                expires_at=expires_at)
+
+    def get_session(self, id: str):
+        res = self.connection.execute(
+            "SELECT id, user_id, expires_at FROM sessions WHERE id = ?", (id,))
+        return res.fetchone()
+
+    def delete_session(self, id: str):
+        with self.connection:
+            self.connection.execute(
+                "DELETE FROM sessions WHERE id = ?", (id,))
 
     def create_conversation(
             self,

--- a/migrations/versions/e5f6a7b8c9d0_add_sessions_table.py
+++ b/migrations/versions/e5f6a7b8c9d0_add_sessions_table.py
@@ -1,0 +1,35 @@
+"""add sessions table
+
+Revision ID: e5f6a7b8c9d0
+Revises: d4e5f6a7b8c9
+Create Date: 2026-08-09 07:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'e5f6a7b8c9d0'
+down_revision: Union[str, Sequence[str], None] = 'd4e5f6a7b8c9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS sessions (
+            id TEXT PRIMARY KEY,
+            user_id INTEGER NOT NULL,
+            expires_at TEXT NOT NULL,
+            FOREIGN KEY(user_id) REFERENCES users(id)
+        );
+    """)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.execute("DROP TABLE IF EXISTS sessions;")

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,0 +1,38 @@
+import os
+import tempfile
+import unittest
+
+from françoise.db import open_db
+from françoise.migrate import upgrade_to_head
+
+
+class TestSessions(unittest.TestCase):
+    def setUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix='.db')
+        os.close(fd)
+        upgrade_to_head(self.db_path)
+
+        with open_db(self.db_path) as db:
+            account = db.create_account('One')[0]
+        with open_db(self.db_path, account_id=account) as db:
+            self.user_id = db.create_user(
+                'Alice', 'alice@example.com', 'hash')[0]
+
+    def tearDown(self):
+        os.remove(self.db_path)
+
+    def test_create_read_delete(self):
+        with open_db(self.db_path) as db:
+            db.create_session('sid', self.user_id, '2099-01-01T00:00:00+00:00')
+
+            session = db.get_session('sid')
+            self.assertIsNotNone(session)
+            self.assertEqual(session[0], 'sid')
+            self.assertEqual(session[1], self.user_id)
+
+            db.delete_session('sid')
+            self.assertIsNone(db.get_session('sid'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Task 12 (#20): store web sessions with id, user_id, expires_at.
Adds migration e5f6a7b8c9d0 and create/get/delete_session in db.py.
