### PR TITLE
Task 15 — add per-user message channels

### DIFF
--- a/françoise/app.py
+++ b/françoise/app.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import re
 import secrets
@@ -53,6 +54,20 @@ def App(**kwargs):
     MAILGUN_API_SENDER = get_config(kwargs, 'MAILGUN_API_SENDER')
     MAILGUN_API_URL = get_config(kwargs, 'MAILGUN_API_URL')
     SERVER_API_KEY = get_config(kwargs, 'SERVER_API_KEY')
+
+    # NOTE one message channel for each user, keyed by user id, so events
+    # route to the right user instead of leaking through a shared queue.
+    # ponytail: plain dict, no eviction; add cleanup when SSE tasks land (#17)
+    channels: dict[int, asyncio.Queue] = {}
+
+    def get_channel(user_id: int) -> asyncio.Queue:
+        channel = channels.get(user_id)
+        if channel is None:
+            channel = channels[user_id] = asyncio.Queue()
+        return channel
+
+    app.state.channels = channels
+    app.state.get_channel = get_channel
 
     def chat_and_reply(
             headers: str,

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -1,0 +1,31 @@
+import asyncio
+import unittest
+
+from françoise.app import App
+
+
+class TestChannels(unittest.TestCase):
+    def test_each_user_has_a_separate_channel(self):
+        app = App(DATABASE_URL=':memory:')
+        get_channel = app.state.get_channel
+
+        one = get_channel(1)
+        two = get_channel(2)
+
+        self.assertIsNot(one, two)
+        # same user reuses the same channel
+        self.assertIs(one, get_channel(1))
+
+    def test_event_routes_to_only_one_user(self):
+        app = App(DATABASE_URL=':memory:')
+        get_channel = app.state.get_channel
+
+        asyncio.run(get_channel(1).put('hello'))
+
+        self.assertEqual(get_channel(1).qsize(), 1)
+        # user two receives nothing
+        self.assertEqual(get_channel(2).qsize(), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Route events per user with a per-user asyncio.Queue keyed by user id,
so one user does not receive another user's events. No shared global
queue exists to remove in this rewrite; the per-user registry is the
seam the SSE stream tasks will consume.
