### PR TITLE
Task 19 — connect the web message route to the core

### DIFF
--- a/françoise/app.py
+++ b/françoise/app.py
@@ -192,18 +192,25 @@ def App(**kwargs):
 
         return StreamingResponse(events(), media_type='text/event-stream')
 
+    async def reply_and_push(user_id: int, conversation_id: int, message: str) -> None:
+        # Generate the reply with the core, then push it to the user's channel.
+        reply = await asyncio.to_thread(handle_inbound, conversation_id, message)
+        await get_channel(user_id).put(reply_fragment(conversation_id, reply))
+
     @app.post('/c/{id}/message', response_class=HTMLResponse)
     def post_message(
             id: int,
             message: Annotated[str, Form()],
+            background_tasks: BackgroundTasks,
             session=Depends(require_session)) -> str:
         with open_db(DATABASE_URL) as resolver:
             account_id = resolver.get_account_id_for_conversation(id)
         if account_id is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
 
-        with open_db(DATABASE_URL, account_id=account_id) as db:
-            db.add_user_message(id, message)
+        # NOTE handle_inbound persists the user message, so the route no longer
+        # saves it; run it off-thread and stream the reply back over /stream.
+        background_tasks.add_task(reply_and_push, session[1], id, message)
 
         # user message partial for an immediate echo
         return '<div>%s</div>' % html.escape(message)

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import unittest
+from unittest.mock import patch
 
 from argon2 import PasswordHasher
 from fastapi.testclient import TestClient
@@ -38,22 +39,27 @@ class TestMessageRoute(unittest.TestCase):
     def tearDown(self):
         os.remove(self.db_path)
 
-    def test_post_message_saves_and_returns_partial(self):
+    def test_post_message_echoes_calls_core_and_pushes_reply(self):
         conversation_id = self.conversation[0]
 
-        response = self.client.post(
-            '/c/%d/message' % conversation_id,
-            data={'message': 'Bonjour'})
+        with patch('françoise.app.handle_inbound', return_value='Salut !') as mock_core:
+            response = self.client.post(
+                '/c/%d/message' % conversation_id,
+                data={'message': 'Bonjour'})
 
         self.assertEqual(response.status_code, 200)
-        # response holds the message partial
+        # response holds the immediate user echo partial
         self.assertIn('Bonjour', response.text)
         self.assertIn('<div>', response.text)
 
-        # store has the message
-        with open_db(self.db_path, account_id=1) as db:
-            messages = db.get_messages_by_conversation(conversation_id)
-        self.assertIn(('user', 'Bonjour'), messages)
+        # the web path runs the core with the posted message
+        mock_core.assert_called_once_with(conversation_id, 'Bonjour')
+
+        # the reply reaches the user's channel as an OOB fragment
+        channel = self.app.state.get_channel(self.user[0])
+        fragment = channel.get_nowait()
+        self.assertIn('id="messages-%d"' % conversation_id, fragment)
+        self.assertIn('Salut !', fragment)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Run handle_inbound off-thread as a background task from POST
/c/{id}/message and push the reply to the user's channel as an OOB
reply fragment, so the reply reaches the browser over /stream.
handle_inbound now owns user-message persistence, so the route no
longer double-saves it.
