### PR TITLE
Task 23 — stream the provider output

### DIFF
--- a/françoise/app.py
+++ b/françoise/app.py
@@ -21,7 +21,7 @@ from fastapi import (
 )
 from fastapi.responses import HTMLResponse, StreamingResponse
 
-from .core import handle_inbound
+from .core import handle_inbound, stream_inbound
 from .db import open_db
 from .mail import parse_conversation_id_from_headers, send_mail
 
@@ -193,9 +193,16 @@ def App(**kwargs):
         return StreamingResponse(events(), media_type='text/event-stream')
 
     async def reply_and_push(user_id: int, conversation_id: int, message: str) -> None:
-        # Generate the reply with the core, then push it to the user's channel.
-        reply = await asyncio.to_thread(handle_inbound, conversation_id, message)
-        await get_channel(user_id).put(reply_fragment(conversation_id, reply))
+        # Stream the reply through the core and push each chunk to the user's
+        # channel so the browser shows the reply as it arrives.
+        channel = get_channel(user_id)
+        chunks = stream_inbound(conversation_id, message)
+        sentinel = object()
+        while True:
+            chunk = await asyncio.to_thread(next, chunks, sentinel)
+            if chunk is sentinel:
+                break
+            await channel.put(reply_fragment(conversation_id, chunk))
 
     @app.post('/c/{id}/message', response_class=HTMLResponse)
     def post_message(

--- a/françoise/chat.py
+++ b/françoise/chat.py
@@ -1,4 +1,4 @@
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 import os
 import litellm
 import requests
@@ -28,6 +28,21 @@ class Provider:
             kwargs['api_key'] = get_secret(credential_ref)
         response = litellm.completion(messages=list(messages), **kwargs)
         return response.choices[0].message.content
+
+    def stream(
+            self,
+            messages: Sequence[dict[str, str]],
+            credential_ref: str = None,
+            **kwargs) -> Iterator[str]:
+        """Yield the reply as a uniform iterator of content chunks."""
+        if credential_ref is not None:
+            kwargs['api_key'] = get_secret(credential_ref)
+        response = litellm.completion(
+            messages=list(messages), stream=True, **kwargs)
+        for chunk in response:
+            content = chunk.choices[0].delta.content
+            if content:
+                yield content
 
 
 def message_tuple_to_dict(values: tuple[str, str]):

--- a/françoise/core.py
+++ b/françoise/core.py
@@ -1,6 +1,12 @@
 import os
+from collections.abc import Iterator
 
-from .chat import chat, get_prompt_message_from_conversation, message_tuple_to_dict
+from .chat import (
+    Provider,
+    chat,
+    get_prompt_message_from_conversation,
+    message_tuple_to_dict,
+)
 from .db import open_db
 
 
@@ -34,3 +40,36 @@ def handle_inbound(conversation_id: int, text: str) -> str:
         db.add_assistant_message(conversation_id, reply)
 
     return reply
+
+
+def stream_inbound(conversation_id: int, text: str) -> Iterator[str]:
+    """Stream a reply for an inbound message, chunk by chunk.
+
+    Same flow as handle_inbound, but yields the reply through the provider
+    seam as it arrives and persists the full reply once the stream ends.
+    """
+    database_url = os.environ.get('DATABASE_URL', 'data.db')
+
+    with open_db(database_url) as resolver:
+        account_id = resolver.get_account_id_for_conversation(conversation_id)
+    if account_id is None:
+        raise Exception('conversation with `id` %d does not exist' % conversation_id)
+
+    with open_db(database_url, account_id=account_id) as db:
+        result = db.get_conversation(conversation_id)
+        if not result:
+            raise Exception('conversation with `id` %d does not exist' % conversation_id)
+
+        conversation = db.conversation_to_dict(result)
+
+        prompt = get_prompt_message_from_conversation(conversation)
+        db.add_user_message(conversation_id, text)
+        messages = db.get_messages_by_conversation(conversation_id)
+        message_objects = list(map(message_tuple_to_dict, [prompt] + messages))
+
+        chunks = []
+        for chunk in Provider().stream(message_objects, model=conversation.get('model')):
+            chunks.append(chunk)
+            yield chunk
+
+        db.add_assistant_message(conversation_id, ''.join(chunks))

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,4 +1,5 @@
 import os
+import re
 import tempfile
 import unittest
 from unittest.mock import patch
@@ -39,10 +40,11 @@ class TestMessageRoute(unittest.TestCase):
     def tearDown(self):
         os.remove(self.db_path)
 
-    def test_post_message_echoes_calls_core_and_pushes_reply(self):
+    def test_post_message_echoes_calls_core_and_streams_reply(self):
         conversation_id = self.conversation[0]
 
-        with patch('françoise.app.handle_inbound', return_value='Salut !') as mock_core:
+        with patch('françoise.app.stream_inbound',
+                   return_value=iter(['Sa', 'lut', ' !'])) as mock_core:
             response = self.client.post(
                 '/c/%d/message' % conversation_id,
                 data={'message': 'Bonjour'})
@@ -52,14 +54,22 @@ class TestMessageRoute(unittest.TestCase):
         self.assertIn('Bonjour', response.text)
         self.assertIn('<div>', response.text)
 
-        # the web path runs the core with the posted message
+        # the web path streams the reply through the core
         mock_core.assert_called_once_with(conversation_id, 'Bonjour')
 
-        # the reply reaches the user's channel as an OOB fragment
+        # each chunk reaches the user's channel as its own OOB fragment
         channel = self.app.state.get_channel(self.user[0])
-        fragment = channel.get_nowait()
-        self.assertIn('id="messages-%d"' % conversation_id, fragment)
-        self.assertIn('Salut !', fragment)
+        fragments = []
+        while not channel.empty():
+            fragments.append(channel.get_nowait())
+
+        self.assertEqual(len(fragments), 3)
+        for fragment in fragments:
+            self.assertIn('id="messages-%d"' % conversation_id, fragment)
+        self.assertEqual(
+            ''.join(re.search(r'<div>(.*)</div></div>', f).group(1)
+                    for f in fragments),
+            'Salut !')
 
 
 if __name__ == '__main__':

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -19,6 +19,23 @@ class TestProvider(unittest.TestCase):
         mock_completion.assert_called_once_with(
             messages=messages, model='ollama/llama3')
 
+    @patch('françoise.chat.litellm.completion')
+    def test_stream_yields_content_chunks(self, mock_completion):
+        def delta(content):
+            return SimpleNamespace(
+                choices=[SimpleNamespace(delta=SimpleNamespace(content=content))])
+
+        # a trailing None delta (finish chunk) is skipped
+        mock_completion.return_value = iter(
+            [delta('Bon'), delta('jour'), delta(None)])
+
+        messages = [{'role': 'user', 'content': 'Hello'}]
+        chunks = list(Provider().stream(messages, model='ollama/llama3'))
+
+        self.assertEqual(chunks, ['Bon', 'jour'])
+        mock_completion.assert_called_once_with(
+            messages=messages, stream=True, model='ollama/llama3')
+
     @patch.dict(os.environ, {'OPENAI_CRED': 'sk-secret'})
     @patch('françoise.chat.litellm.completion')
     def test_chat_reads_key_by_reference(self, mock_completion):


### PR DESCRIPTION
Turn on streaming in the provider seam (Provider.stream yields content
chunks as a uniform iterator), add stream_inbound to the core to route
the reply through the seam and persist it, and push each chunk to the
user's SSE stream so the browser shows the reply as it arrives.

Closes #31
