### PR TITLE
Task 24 — add the native Anthropic path

### DIFF
--- a/françoise/chat.py
+++ b/françoise/chat.py
@@ -1,5 +1,6 @@
 from collections.abc import Iterator, Sequence
 import os
+import anthropic
 import litellm
 import requests
 
@@ -16,6 +17,22 @@ def get_secret(credential_ref: str) -> str:
     return key
 
 
+def is_anthropic_model(model: str) -> bool:
+    """Select the native path for Claude configs (LiteLLM's `anthropic/` prefix)."""
+    return bool(model) and model.startswith('anthropic/')
+
+
+def split_system(messages: Sequence[dict[str, str]]) -> tuple[str, list[dict[str, str]]]:
+    """Separate the system prompt from the conversation turns.
+
+    The Anthropic Messages API takes `system` as a top-level field, not a role
+    inside `messages`, so we lift it out here.
+    """
+    system = '\n'.join(m['content'] for m in messages if m['role'] == 'system')
+    turns = [m for m in messages if m['role'] != 'system']
+    return system, turns
+
+
 class Provider:
     """Thin seam over LiteLLM so we can reach many model hosts through one interface."""
 
@@ -24,10 +41,35 @@ class Provider:
             messages: Sequence[dict[str, str]],
             credential_ref: str = None,
             **kwargs) -> str:
+        if is_anthropic_model(kwargs.get('model')):
+            return self._anthropic_chat(messages, credential_ref, **kwargs)
         if credential_ref is not None:
             kwargs['api_key'] = get_secret(credential_ref)
         response = litellm.completion(messages=list(messages), **kwargs)
         return response.choices[0].message.content
+
+    def _anthropic_chat(
+            self,
+            messages: Sequence[dict[str, str]],
+            credential_ref: str = None,
+            **kwargs) -> str:
+        """Native Anthropic path: cache the system prompt to cut repeat cost."""
+        api_key = get_secret(credential_ref) if credential_ref is not None else None
+        # Strip LiteLLM's `anthropic/` prefix to the bare model id the SDK wants.
+        model = kwargs.pop('model').removeprefix('anthropic/')
+        kwargs.setdefault('max_tokens', 16000)
+        system, turns = split_system(messages)
+
+        response = anthropic.Anthropic(api_key=api_key).messages.create(
+            model=model,
+            system=[{
+                'type': 'text',
+                'text': system,
+                'cache_control': {'type': 'ephemeral'},
+            }],
+            messages=turns,
+            **kwargs)
+        return response.content[0].text
 
     def stream(
             self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 requires-python = ">=3.14"
 dependencies = [
     "alembic==1.19.1",
+    "anthropic==0.121.0",
     "argon2-cffi==25.1.0",
     "fastapi[standard]==0.120.2",
     "litellm==1.96.0",

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -48,6 +48,33 @@ class TestProvider(unittest.TestCase):
         mock_completion.assert_called_once_with(
             messages=messages, model='gpt-4', api_key='sk-secret')
 
+    @patch('françoise.chat.litellm.completion')
+    @patch('françoise.chat.anthropic.Anthropic')
+    def test_chat_uses_native_anthropic_path_with_caching(
+            self, mock_anthropic, mock_completion):
+        mock_anthropic.return_value.messages.create.return_value = SimpleNamespace(
+            content=[SimpleNamespace(text='Bonjour !')])
+
+        messages = [
+            {'role': 'system', 'content': 'You are Françoise.'},
+            {'role': 'user', 'content': 'Hello'}]
+        reply = Provider().chat(messages, model='anthropic/claude-opus-4-8')
+
+        self.assertEqual(reply, 'Bonjour !')
+        # The native path runs, not LiteLLM.
+        mock_completion.assert_not_called()
+
+        _, kwargs = mock_anthropic.return_value.messages.create.call_args
+        # The bare model id reaches the SDK, the system prompt is lifted out
+        # of the turns, and it is cached.
+        self.assertEqual(kwargs['model'], 'claude-opus-4-8')
+        self.assertEqual(kwargs['messages'], [{'role': 'user', 'content': 'Hello'}])
+        self.assertEqual(kwargs['system'], [{
+            'type': 'text',
+            'text': 'You are Françoise.',
+            'cache_control': {'type': 'ephemeral'},
+        }])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Route Claude configs (LiteLLM's anthropic/ prefix) through the Anthropic
SDK instead of LiteLLM, lifting the system prompt into the top-level
system field and marking it cache_control ephemeral so repeat calls read
the cached prefix. LiteLLM stays the path for every other host.
