### PR TITLE
Seed the persona into the graph on agent create (#35)

### DIFF
--- a/françoise/graph.py
+++ b/françoise/graph.py
@@ -1,24 +1,54 @@
 from contextlib import contextmanager
 
-from pyoxigraph import NamedNode, Quad, Store
+from pyoxigraph import DefaultGraph, Literal, NamedNode, Quad, Store
 
-from françoise.vocab import PREDICATES
+from françoise.vocab import (
+    FR_PREDICATES,
+    GRAPHS,
+    PREDICATES,
+    SCHEMA_PREDICATES,
+    agent_iri,
+    topic_iri,
+)
 
 
 class Graph:
     def __init__(self, store):
         self.store = store
 
-    def assert_quad(self, subject: str, predicate: str, object: str):
+    def assert_quad(
+            self,
+            subject: str,
+            predicate: str,
+            object: str,
+            graph: str = None,
+            literal: bool = False):
         if predicate not in PREDICATES:
             raise ValueError('unknown predicate: %s' % predicate)
         self.store.add(Quad(
             NamedNode(subject),
             NamedNode(predicate),
-            NamedNode(object)))
+            Literal(object) if literal else NamedNode(object),
+            NamedNode(graph) if graph else DefaultGraph()))
 
     def query(self, sparql: str):
         return self.store.query(sparql)
+
+    def seed_persona(self, agent_id: int, name: str, interests=()):
+        """Write an agent's persona facts into the `real` graph: its own
+        name, and for each interest a topic node linked by a trait edge."""
+        real = GRAPHS['real']
+        agent = agent_iri(agent_id)
+        self.assert_quad(
+            agent, SCHEMA_PREDICATES['name'], name,
+            graph=real, literal=True)
+        for interest in interests:
+            topic = topic_iri(interest)
+            self.assert_quad(
+                topic, SCHEMA_PREDICATES['name'], interest,
+                graph=real, literal=True)
+            self.assert_quad(
+                agent, FR_PREDICATES['enjoys'], topic, graph=real)
 
 
 @contextmanager

--- a/françoise/vocab.py
+++ b/françoise/vocab.py
@@ -1,6 +1,8 @@
 """The vocabulary: Schema.org classes and predicates, local fr: predicates,
 and the names of the provenance graphs. Everything lives here in one place."""
 
+from urllib.parse import quote
+
 SCHEMA = 'https://schema.org/'
 FR = 'https://françoise.example/vocab#'
 
@@ -38,3 +40,13 @@ GRAPHS = {
     'synthetic': FR + 'graph/synthetic',
     'inferred': FR + 'graph/inferred',
 }
+
+
+def agent_iri(agent_id: int) -> str:
+    """The IRI for an agent's self node."""
+    return FR + 'agent/%d' % agent_id
+
+
+def topic_iri(interest: str) -> str:
+    """The IRI for an interest's topic node."""
+    return FR + 'topic/' + quote(interest.strip().lower(), safe='')

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -3,7 +3,13 @@ import tempfile
 import unittest
 
 from françoise.graph import open_graph
-from françoise.vocab import FR_PREDICATES
+from françoise.vocab import (
+    FR_PREDICATES,
+    GRAPHS,
+    SCHEMA_PREDICATES,
+    agent_iri,
+    topic_iri,
+)
 
 
 class TestGraph(unittest.TestCase):
@@ -35,6 +41,28 @@ class TestGraph(unittest.TestCase):
                     'http://example.com/subject',
                     'http://example.com/unknown',
                     'http://example.com/object')
+
+
+    def test_seed_persona(self):
+        with open_graph(self.path) as graph:
+            graph.seed_persona(1, 'Boku', interests=['cinema', 'cooking'])
+
+            agent = agent_iri(1)
+            real = GRAPHS['real']
+
+            # The agent has a self name fact in the real graph.
+            rows = list(graph.query(
+                'SELECT ?o WHERE { GRAPH <%s> { <%s> <%s> ?o } }'
+                % (real, agent, SCHEMA_PREDICATES['name'])))
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(str(rows[0]['o']), '"Boku"')
+
+            # Each interest has a topic node and a trait edge.
+            for interest in ('cinema', 'cooking'):
+                topic = topic_iri(interest)
+                self.assertTrue(bool(graph.query(
+                    'ASK { GRAPH <%s> { <%s> <%s> <%s> } }'
+                    % (real, agent, FR_PREDICATES['enjoys'], topic))))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add Graph.seed_persona to write an agent's self name fact plus a topic
node and fr:enjoys trait edge per interest into the real graph. Extend
assert_quad with named-graph and literal object support, and add
agent_iri/topic_iri vocab helpers.
