### PR TITLE
Task 30 — add the extraction pass

### DIFF
--- a/françoise/extract.py
+++ b/françoise/extract.py
@@ -1,0 +1,36 @@
+"""The extraction pass: turn a message into facts in the background.
+
+Reads a message's text, extracts entities and events from it, resolves each
+entity against the IRIs already in the `real` graph, and asserts the new facts
+with the source message id. The extractor — the natural-language step — is
+injectable so the resolve-and-assert flow stays deterministic and testable.
+"""
+
+import os
+
+from .graph import open_graph
+
+
+def default_extractor(text: str) -> list[tuple[str, str, str]]:
+    """Extract `(subject, predicate, object)` facts from message text.
+
+    A placeholder for the LLM extraction step. Returns nothing so an unwired
+    deployment asserts nothing rather than guessing.
+    """
+    # ponytail: no-op until the LLM extractor lands; inject one via `extract`.
+    return []
+
+
+def extract(message_id: int, text: str, extractor=default_extractor):
+    """Extract facts from a message and assert them into the `real` graph.
+
+    Medium-agnostic and safe to run in the background: it opens the graph,
+    runs the extractor over the text, and hands the facts to the graph, which
+    resolves each entity to an existing IRI before asserting it.
+    """
+    graph_path = os.environ.get('GRAPH_PATH', 'graph.db')
+    facts = extractor(text)
+    if not facts:
+        return
+    with open_graph(graph_path) as graph:
+        graph.extract_facts(message_id, facts)

--- a/françoise/graph.py
+++ b/françoise/graph.py
@@ -8,6 +8,8 @@ from françoise.vocab import (
     PREDICATES,
     SCHEMA_PREDICATES,
     agent_iri,
+    entity_iri,
+    message_iri,
     topic_iri,
 )
 
@@ -70,6 +72,49 @@ class Graph:
                 return names[0]['n'].value
             return node.value
         return str(node)
+
+    def resolve_iri(self, name: str) -> str:
+        """The IRI of an existing entity with this `name`, else a fresh one.
+
+        Matches the `name` literal of any node already in the `real` graph so a
+        known entity keeps its IRI instead of being asserted twice.
+        """
+        real = GRAPHS['real']
+        rows = list(self.query(
+            'SELECT ?s WHERE { GRAPH <%s> { ?s <%s> %s } } LIMIT 1'
+            % (real, SCHEMA_PREDICATES['name'], Literal(name))))
+        if rows:
+            return rows[0]['s'].value
+        return entity_iri(name)
+
+    def extract_facts(self, message_id: int, facts):
+        """Assert extracted `(subject, predicate, object)` facts into `real`.
+
+        Each subject and object is resolved to an existing IRI when its name is
+        already known, else minted fresh and given a `name` literal. Every
+        asserted subject is linked to its source message so the fact's
+        provenance is kept. `facts` is an iterable of name/predicate/name
+        triples, e.g. from an extractor over the message text.
+        """
+        real = GRAPHS['real']
+        source = message_iri(message_id)
+        for subject_name, predicate, object_name in facts:
+            subject = self.resolve_iri(subject_name)
+            object = self.resolve_iri(object_name)
+            self._ensure_name(subject, subject_name)
+            self._ensure_name(object, object_name)
+            self.assert_quad(subject, predicate, object, graph=real)
+            self.assert_quad(
+                source, SCHEMA_PREDICATES['mentions'], subject, graph=real)
+
+    def _ensure_name(self, iri: str, name: str):
+        """Give a node its `name` literal in `real` if it lacks one."""
+        real = GRAPHS['real']
+        if not bool(self.query(
+                'ASK { GRAPH <%s> { <%s> <%s> ?n } }'
+                % (real, iri, SCHEMA_PREDICATES['name']))):
+            self.assert_quad(
+                iri, SCHEMA_PREDICATES['name'], name, graph=real, literal=True)
 
     def seed_persona(self, agent_id: int, name: str, interests=()):
         """Write an agent's persona facts into the `real` graph: its own

--- a/françoise/vocab.py
+++ b/françoise/vocab.py
@@ -21,6 +21,7 @@ SCHEMA_PREDICATES = {
     'knows': SCHEMA + 'knows',
     'memberOf': SCHEMA + 'memberOf',
     'homeLocation': SCHEMA + 'homeLocation',
+    'mentions': SCHEMA + 'mentions',
 }
 
 # Local fr: predicates.
@@ -50,3 +51,13 @@ def agent_iri(agent_id: int) -> str:
 def topic_iri(interest: str) -> str:
     """The IRI for an interest's topic node."""
     return FR + 'topic/' + quote(interest.strip().lower(), safe='')
+
+
+def entity_iri(name: str) -> str:
+    """A fresh IRI for an entity, minted from its name."""
+    return FR + 'entity/' + quote(name.strip().lower(), safe='')
+
+
+def message_iri(message_id: int) -> str:
+    """The IRI for a source message node."""
+    return FR + 'message/%d' % message_id

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,0 +1,65 @@
+import os
+import shutil
+import tempfile
+import unittest
+
+from françoise.extract import extract
+from françoise.graph import open_graph
+from françoise.vocab import (
+    GRAPHS,
+    SCHEMA_PREDICATES,
+    message_iri,
+)
+
+
+class TestExtract(unittest.TestCase):
+    def setUp(self):
+        self.path = tempfile.mkdtemp()
+        os.environ['GRAPH_PATH'] = self.path
+
+    def tearDown(self):
+        os.environ.pop('GRAPH_PATH', None)
+        shutil.rmtree(self.path)
+
+    def test_asserts_fact_from_message(self):
+        # A message with a clear fact: Alice knows Bob.
+        def extractor(text):
+            return [('Alice', SCHEMA_PREDICATES['knows'], 'Bob')]
+
+        extract(7, 'Alice knows Bob.', extractor=extractor)
+
+        real = GRAPHS['real']
+        with open_graph(self.path) as graph:
+            # The fact is asserted, exactly once.
+            rows = list(graph.query(
+                'SELECT ?s ?o WHERE { GRAPH <%s> { ?s <%s> ?o } }'
+                % (real, SCHEMA_PREDICATES['knows'])))
+            self.assertEqual(len(rows), 1)
+            # It is linked to its source message.
+            self.assertTrue(bool(graph.query(
+                'ASK { GRAPH <%s> { <%s> <%s> ?s } }'
+                % (real, message_iri(7), SCHEMA_PREDICATES['mentions']))))
+
+    def test_reuses_iri_for_known_entity(self):
+        def extractor(text):
+            return [('Alice', SCHEMA_PREDICATES['knows'], 'Bob')]
+
+        extract(1, 'Alice knows Bob.', extractor=extractor)
+        extract(2, 'Alice knows Bob.', extractor=extractor)
+
+        real = GRAPHS['real']
+        with open_graph(self.path) as graph:
+            # Alice keeps one IRI across both messages, so one name node.
+            rows = list(graph.query(
+                'SELECT ?s WHERE { GRAPH <%s> { ?s <%s> "Alice" } }'
+                % (real, SCHEMA_PREDICATES['name'])))
+            self.assertEqual(len(rows), 1)
+            # The fact itself is held once, not duplicated.
+            facts = list(graph.query(
+                'SELECT ?s ?o WHERE { GRAPH <%s> { ?s <%s> ?o } }'
+                % (real, SCHEMA_PREDICATES['knows'])))
+            self.assertEqual(len(facts), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Turn messages into facts in the background: extract entities and events
from a message, resolve each entity against existing IRIs before asserting
it, and assert new facts into the `real` graph with the source message id.

Closes #38
