### PR TITLE
Add temporal context to the prompt

### DIFF
--- a/françoise/persona.py
+++ b/françoise/persona.py
@@ -5,7 +5,23 @@ composed from trusted fields we control, so user-supplied text can never reach
 it. The user's text is passed to the model as a user message instead.
 """
 
+from datetime import datetime
+
 PERSONA_FIELDS = ('location', 'timezone', 'interests', 'age', 'native_language')
+
+# ponytail: northern-hemisphere seasons by month; add hemisphere lookup if
+# southern-hemisphere personas ever matter.
+_SEASONS = ('winter', 'spring', 'summer', 'autumn')
+
+
+def temporal_context(now: datetime = None) -> str:
+    """Render the local date, weekday, and season as prompt lines."""
+    now = now or datetime.now()
+    season = _SEASONS[(now.month % 12) // 3]
+    return '\n'.join((
+        'Today is %s.' % now.strftime('%A, %B %d, %Y'),
+        'The season is %s.' % season,
+    ))
 
 LABELS = {
     'location': 'Location',
@@ -37,7 +53,7 @@ def build_prompt(agent: dict, facts=(), messages=(), window: int = 20) -> str:
     the last `window` turns form the short-term memory. Both memory sections
     are trusted context we control, kept out of the user message stream.
     """
-    parts = [build_persona_prompt(agent)]
+    parts = [build_persona_prompt(agent), temporal_context()]
     if facts:
         parts.append('Facts you remember:\n' + '\n'.join(facts))
     recent = list(messages)[-window:]

--- a/tests/test_persona.py
+++ b/tests/test_persona.py
@@ -1,6 +1,7 @@
 import unittest
+from datetime import datetime
 
-from françoise.persona import build_persona_prompt, build_prompt
+from françoise.persona import build_persona_prompt, build_prompt, temporal_context
 
 
 class TestPersona(unittest.TestCase):
@@ -51,6 +52,17 @@ class TestPersona(unittest.TestCase):
         prompt = build_prompt(self.agent, messages=messages, window=5)
         self.assertIn('m29', prompt)
         self.assertNotIn('m0\n', prompt)
+
+
+    def test_prompt_holds_date_and_weekday(self):
+        prompt = build_prompt(self.agent)
+        now = datetime.now()
+        self.assertIn(now.strftime('%A'), prompt)  # weekday
+        self.assertIn(now.strftime('%Y'), prompt)  # date
+
+    def test_temporal_context_reports_season(self):
+        self.assertIn('summer', temporal_context(datetime(2026, 7, 1)))
+        self.assertIn('winter', temporal_context(datetime(2026, 1, 1)))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Include the local date, weekday, and season in the assembled prompt so
the persona knows the real time. Closes #40.
