### PR TITLE
Task 33 — defer replies outside waking hours

### DIFF
--- a/françoise/app.py
+++ b/françoise/app.py
@@ -24,6 +24,7 @@ from fastapi.responses import HTMLResponse, StreamingResponse
 from .core import handle_inbound, stream_inbound
 from .db import open_db
 from .mail import parse_conversation_id_from_headers, send_mail
+from .presence import is_free
 
 LOGIN_FORM = """<!DOCTYPE html>
 <html lang="en">
@@ -192,9 +193,25 @@ def App(**kwargs):
 
         return StreamingResponse(events(), media_type='text/event-stream')
 
+    def get_agent(conversation_id: int) -> dict:
+        # The persona fields presence reads (timezone/age) ride on the
+        # conversation dict; absent ones fall back to UTC/adult in presence.
+        with open_db(DATABASE_URL) as resolver:
+            account_id = resolver.get_account_id_for_conversation(conversation_id)
+        with open_db(DATABASE_URL, account_id=account_id) as db:
+            return db.conversation_to_dict(db.get_conversation(conversation_id))
+
+    async def wait_until_free(agent: dict, poll: float = 60.0) -> None:
+        # Hold here while the persona is asleep/at school; wake in the next
+        # free window. Re-checks presence each poll against the moving clock.
+        while not is_free(agent):
+            await asyncio.sleep(poll)
+
     async def reply_and_push(user_id: int, conversation_id: int, message: str) -> None:
         # Stream the reply through the core and push each chunk to the user's
-        # channel so the browser shows the reply as it arrives.
+        # channel so the browser shows the reply as it arrives. Hold the reply
+        # until the persona is free (not asleep or at school).
+        await wait_until_free(get_agent(conversation_id))
         channel = get_channel(user_id)
         chunks = stream_inbound(conversation_id, message)
         sentinel = object()

--- a/françoise/db.py
+++ b/françoise/db.py
@@ -247,7 +247,9 @@ class Database:
                 agent.name AS agent_name,
                 agent.language AS agent_language,
                 agent.proficiency AS agent_proficiency,
-                agent.prompt AS agent_prompt
+                agent.prompt AS agent_prompt,
+                agent.timezone AS timezone,
+                agent.age AS age
             FROM conversations conversation
             JOIN users user
             ON conversation.user_id = user.id
@@ -269,7 +271,9 @@ class Database:
                          'agent_name',
                          'agent_language',
                          'agent_proficiency',
-                         'agent_prompt'),
+                         'agent_prompt',
+                         'timezone',
+                         'age'),
                     conversation))
 
     def get_messages_by_conversation(self, conversation_id: int):

--- a/françoise/presence.py
+++ b/françoise/presence.py
@@ -56,6 +56,15 @@ def presence_state(agent: dict, now: datetime = None) -> str:
     return _schedule(agent.get('age'))[now.hour]
 
 
+# States in which the persona holds a reply rather than sending it now.
+DEFERRED_STATES = ('asleep', 'school')
+
+
+def is_free(agent: dict, now: datetime = None) -> bool:
+    """True when the persona may reply now (state is not deferred)."""
+    return presence_state(agent, now) not in DEFERRED_STATES
+
+
 if __name__ == '__main__':
     child = {'timezone': 'UTC', 'age': 10}
     at = lambda h: datetime(2026, 1, 1, h, tzinfo=ZoneInfo('UTC'))

--- a/tests/test_defer.py
+++ b/tests/test_defer.py
@@ -1,0 +1,82 @@
+import os
+import tempfile
+import unittest
+from datetime import datetime
+from unittest.mock import patch
+from zoneinfo import ZoneInfo
+
+from argon2 import PasswordHasher
+from fastapi.testclient import TestClient
+
+from françoise.app import App
+from françoise.db import open_db
+from françoise.migrate import upgrade_to_head
+from françoise.presence import is_free
+
+
+def _at(hour):
+    return datetime(2026, 1, 1, hour, tzinfo=ZoneInfo('UTC'))
+
+
+class TestIsFree(unittest.TestCase):
+    def test_asleep_is_not_free(self):
+        self.assertFalse(is_free({'timezone': 'UTC', 'age': 10}, _at(2)))
+
+    def test_school_is_not_free(self):
+        self.assertFalse(is_free({'timezone': 'UTC', 'age': 10}, _at(10)))
+
+    def test_free_window_is_free(self):
+        self.assertTrue(is_free({'timezone': 'UTC', 'age': 10}, _at(16)))
+
+
+class TestDeferReply(unittest.TestCase):
+    def setUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix='.db')
+        os.close(fd)
+
+        upgrade_to_head(self.db_path)
+        password_hash = PasswordHasher().hash('correct horse')
+        with open_db(self.db_path) as db:
+            account = db.create_account('Acme')
+        with open_db(self.db_path, account_id=account[0]) as db:
+            self.user = db.create_user('Alice', 'alice@example.com', password_hash)
+            agent = db.create_agent('Boku', 'French', 'A1', 'You are {agent_name}.')
+            self.conversation = db.create_conversation(
+                user_id=self.user[0],
+                agent_id=agent[0],
+                proficiency='A1',
+                model='test-model')
+
+        self.app = App(DATABASE_URL=self.db_path)
+        self.client = TestClient(self.app)
+        self.client.post('/login', data={
+            'email': 'alice@example.com',
+            'password': 'correct horse'})
+
+    def tearDown(self):
+        os.remove(self.db_path)
+
+    def _post(self):
+        # No wall-clock waits: the poll sleep is a no-op in the test.
+        with patch('françoise.app.asyncio.sleep', return_value=None), \
+                patch('françoise.app.stream_inbound', return_value=iter(['Bonjour !'])):
+            self.client.post(
+                '/c/%d/message' % self.conversation[0],
+                data={'message': 'Hello'})
+
+    def test_reply_waits_while_asleep_then_sends_when_free(self):
+        channel = self.app.state.get_channel(self.user[0])
+
+        # Asleep now, free on the next check: the persona holds the reply
+        # through the sleep window and sends it in the first free window.
+        states = iter([False, True])
+        with patch('françoise.app.is_free', side_effect=lambda *a: next(states)):
+            self._post()
+
+        # The reply reached the stream once the persona was free.
+        self.assertFalse(channel.empty())
+        self.assertIn('Bonjour !', channel.get_nowait())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hold a streamed reply until the persona is free: check presence before
pushing to the SSE channel and wait out asleep/school windows, sending
in the next free window.

- presence: add is_free() and DEFERRED_STATES
- app: reply_and_push waits until free before streaming
- db: select agent timezone/age so presence reads the real schedule
