### PR TITLE
Add the grounding step (task 38)

### DIFF
--- a/françoise/graph.py
+++ b/françoise/graph.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 from pyoxigraph import DefaultGraph, Literal, NamedNode, Quad, Store
 
 from françoise.vocab import (
+    FR,
     FR_PREDICATES,
     GRAPHS,
     PREDICATES,
@@ -129,6 +130,30 @@ class Graph:
         self.assert_quad(
             place_iri(region), FR_PREDICATES['signal'], summary,
             graph=GRAPHS['world'], literal=True)
+
+    def persona_terms(self, agent_id: int) -> set[str]:
+        """The agent's grounding terms: its interests, home location, and the
+        names of known topics, lowercased.
+
+        Read from the `real` graph, these are the terms a world signal must
+        touch to fit the persona: an interest edge (`enjoys` a named topic),
+        the `homeLocation` name, or any known topic node's name.
+        """
+        real = GRAPHS['real']
+        agent = agent_iri(agent_id)
+        rows = self.query("""
+            SELECT ?name WHERE { GRAPH <%s> {
+                { <%s> <%s> ?t . ?t <%s> ?name }
+                UNION { <%s> <%s> ?h . ?h <%s> ?name }
+                UNION { ?t <%s> ?name . FILTER(STRSTARTS(STR(?t), "%s")) }
+            } }
+        """ % (
+            real,
+            agent, FR_PREDICATES['enjoys'], SCHEMA_PREDICATES['name'],
+            agent, SCHEMA_PREDICATES['homeLocation'], SCHEMA_PREDICATES['name'],
+            SCHEMA_PREDICATES['name'], FR + 'topic/',
+        ))
+        return {r['name'].value.lower() for r in rows}
 
     def seed_persona(self, agent_id: int, name: str, interests=()):
         """Write an agent's persona facts into the `real` graph: its own

--- a/françoise/signals.py
+++ b/françoise/signals.py
@@ -90,6 +90,26 @@ def region_signals(graph, region: str, latitude: float, longitude: float,
     return signals
 
 
+def _signal_terms(signal: dict) -> set[str]:
+    """The lowercased string values of a signal, used to match the persona."""
+    return {
+        str(value).lower()
+        for value in signal.values()
+        if isinstance(value, str)
+    }
+
+
+def ground_signals(graph, agent_id: int, signals) -> list[dict]:
+    """Keep only the signals that fit the agent's persona.
+
+    A signal stays when one of its values matches a persona term: an interest
+    edge, the home location, or a known topic (see `Graph.persona_terms`). A
+    signal that matches nothing drops.
+    """
+    terms = graph.persona_terms(agent_id)
+    return [s for s in signals if _signal_terms(s) & terms]
+
+
 if __name__ == '__main__':
     xmas = calendar_signal(date(2026, 12, 25))
     assert xmas['topic'] == 'calendar'

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -4,7 +4,12 @@ import unittest
 from datetime import date
 
 from françoise.graph import open_graph
-from françoise.signals import calendar_signal, region_signals, weather_signal
+from françoise.signals import (
+    calendar_signal,
+    ground_signals,
+    region_signals,
+    weather_signal,
+)
 from françoise.vocab import FR_PREDICATES, GRAPHS, place_iri
 
 
@@ -104,6 +109,24 @@ class TestRegionSignals(unittest.TestCase):
 
         # Both the weather and calendar signals are held for the region.
         self.assertEqual(len(rows), 2)
+
+
+class TestGroundSignals(unittest.TestCase):
+    def setUp(self):
+        self.path = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.path)
+
+    def test_keeps_only_the_matching_signal(self):
+        matching = {'topic': 'cinema', 'note': 'a new film'}
+        non_matching = {'topic': 'weather', 'note': 'it rains'}
+        with open_graph(self.path) as graph:
+            graph.seed_persona(1, 'Boku', interests=['cinema'])
+
+            grounded = ground_signals(graph, 1, [matching, non_matching])
+
+        self.assertEqual(grounded, [matching])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Keep only world signals that fit the persona: a signal stays when one of
its values matches an interest edge, the home location, or a known topic;
one that matches nothing drops.
