### PR TITLE
Add the synthesis step (Task 39)

### DIFF
--- a/françoise/graph.py
+++ b/françoise/graph.py
@@ -10,6 +10,7 @@ from françoise.vocab import (
     SCHEMA_PREDICATES,
     agent_iri,
     entity_iri,
+    event_iri,
     message_iri,
     place_iri,
     topic_iri,
@@ -130,6 +131,40 @@ class Graph:
         self.assert_quad(
             place_iri(region), FR_PREDICATES['signal'], summary,
             graph=GRAPHS['world'], literal=True)
+
+    def read_events(self, agent_id: int) -> list[str]:
+        """The agent's past synthetic events as first-person text lines."""
+        synthetic = GRAPHS['synthetic']
+        rows = self.query(
+            'SELECT ?t WHERE { GRAPH <%s> { <%s> <%s> ?e . ?e <%s> ?t } }'
+            % (synthetic, agent_iri(agent_id), SCHEMA_PREDICATES['mentions'],
+               SCHEMA_PREDICATES['name']))
+        return [r['t'].value for r in rows]
+
+    def assert_synthetic_event(self, agent_id: int, region: str, text: str) -> bool:
+        """Assert a first-person event into the `synthetic` graph.
+
+        Mints an event node from `text`, gives it a `name` literal, links the
+        agent to it, and links it to the region's world node so the event keeps
+        its world signal. Returns False without asserting when the same event
+        already exists (a conflict), True otherwise.
+        """
+        synthetic = GRAPHS['synthetic']
+        event = event_iri(text)
+        if bool(self.query(
+                'ASK { GRAPH <%s> { <%s> <%s> ?t } }'
+                % (synthetic, event, SCHEMA_PREDICATES['name']))):
+            return False
+        self.assert_quad(
+            event, SCHEMA_PREDICATES['name'], text,
+            graph=synthetic, literal=True)
+        self.assert_quad(
+            agent_iri(agent_id), SCHEMA_PREDICATES['mentions'], event,
+            graph=synthetic)
+        self.assert_quad(
+            event, SCHEMA_PREDICATES['mentions'], place_iri(region),
+            graph=synthetic)
+        return True
 
     def persona_terms(self, agent_id: int) -> set[str]:
         """The agent's grounding terms: its interests, home location, and the

--- a/françoise/signals.py
+++ b/françoise/signals.py
@@ -110,6 +110,37 @@ def ground_signals(graph, agent_id: int, signals) -> list[dict]:
     return [s for s in signals if _signal_terms(s) & terms]
 
 
+def default_model(persona: str, past_events, signal: dict) -> str:
+    """Draft a first-person event from a grounded signal.
+
+    A placeholder for the LLM synthesis step. Returns nothing so an unwired
+    deployment synthesizes nothing rather than guessing. Inject a real model
+    via `synthesize`.
+    """
+    # ponytail: no-op until the LLM model lands; inject one via `synthesize`.
+    return ''
+
+
+def synthesize(graph, agent_id: int, signal: dict, model=default_model) -> str:
+    """Make a first-person synthetic event from a grounded world signal.
+
+    Asks `model` for an event that fits the persona and the past events, checks
+    it against the graph for a conflict (an identical event already asserted),
+    and asserts it into the `synthetic` graph linked to the region's world
+    node. Returns the event text, or '' when the model drafts nothing or the
+    event conflicts. `model` is injected so the assert flow stays testable.
+    """
+    terms = graph.persona_terms(agent_id)
+    persona = ', '.join(sorted(terms))
+    text = model(persona, graph.read_events(agent_id), signal).strip()
+    if not text:
+        return ''
+    region = signal.get('place', '')
+    if not graph.assert_synthetic_event(agent_id, region, text):
+        return ''
+    return text
+
+
 if __name__ == '__main__':
     xmas = calendar_signal(date(2026, 12, 25))
     assert xmas['topic'] == 'calendar'

--- a/françoise/vocab.py
+++ b/françoise/vocab.py
@@ -67,3 +67,8 @@ def message_iri(message_id: int) -> str:
 def place_iri(place: str) -> str:
     """The IRI for a place (a region) node."""
     return FR + 'place/' + quote(place.strip().lower(), safe='')
+
+
+def event_iri(text: str) -> str:
+    """The IRI for a synthetic event node, minted from its text."""
+    return FR + 'event/' + quote(text.strip().lower(), safe='')

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -8,9 +8,17 @@ from françoise.signals import (
     calendar_signal,
     ground_signals,
     region_signals,
+    synthesize,
     weather_signal,
 )
-from françoise.vocab import FR_PREDICATES, GRAPHS, place_iri
+from françoise.vocab import (
+    FR_PREDICATES,
+    GRAPHS,
+    SCHEMA_PREDICATES,
+    agent_iri,
+    event_iri,
+    place_iri,
+)
 
 
 class _Resp:
@@ -127,6 +135,59 @@ class TestGroundSignals(unittest.TestCase):
             grounded = ground_signals(graph, 1, [matching, non_matching])
 
         self.assertEqual(grounded, [matching])
+
+
+class TestSynthesize(unittest.TestCase):
+    def setUp(self):
+        self.path = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.path)
+
+    def test_asserts_a_synthetic_event_linked_to_the_world_signal(self):
+        signal = {'topic': 'cinema', 'place': 'Paris', 'note': 'a new film'}
+        model = lambda persona, past, s: 'I went to see the new film.'
+        synthetic = GRAPHS['synthetic']
+        with open_graph(self.path) as graph:
+            graph.seed_persona(1, 'Boku', interests=['cinema'])
+            grounded = ground_signals(graph, 1, [signal])
+
+            text = synthesize(graph, 1, grounded[0], model=model)
+
+            self.assertEqual(text, 'I went to see the new film.')
+            event = event_iri(text)
+            # The synthetic graph holds the event with its first-person text.
+            self.assertTrue(bool(graph.query(
+                'ASK { GRAPH <%s> { <%s> <%s> "%s" } }'
+                % (synthetic, event, SCHEMA_PREDICATES['name'], text))))
+            # The event links to its world signal (the region's world node).
+            self.assertTrue(bool(graph.query(
+                'ASK { GRAPH <%s> { <%s> <%s> <%s> } }'
+                % (synthetic, event, SCHEMA_PREDICATES['mentions'],
+                   place_iri('Paris')))))
+            # The agent owns the event.
+            self.assertTrue(bool(graph.query(
+                'ASK { GRAPH <%s> { <%s> <%s> <%s> } }'
+                % (synthetic, agent_iri(1), SCHEMA_PREDICATES['mentions'],
+                   event))))
+
+    def test_conflict_is_not_reasserted(self):
+        signal = {'topic': 'cinema', 'place': 'Paris'}
+        model = lambda persona, past, s: 'I went to see the new film.'
+        synthetic = GRAPHS['synthetic']
+        with open_graph(self.path) as graph:
+            graph.seed_persona(1, 'Boku', interests=['cinema'])
+
+            first = synthesize(graph, 1, signal, model=model)
+            second = synthesize(graph, 1, signal, model=model)
+
+            self.assertEqual(first, 'I went to see the new film.')
+            self.assertEqual(second, '')
+            # The event is held once, not duplicated.
+            rows = list(graph.query(
+                'SELECT ?e WHERE { GRAPH <%s> { ?e <%s> ?t } }'
+                % (synthetic, SCHEMA_PREDICATES['name'])))
+            self.assertEqual(len(rows), 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Make a first-person synthetic event from a grounded world signal: ask an
injectable model for an event fitting the persona and past events, check the
graph for a conflict, and assert it into the synthetic graph linked to the
region's world node.

Closes #47
