### PR TITLE
Add the contact step (Task 40)

### DIFF
--- a/françoise/signals.py
+++ b/françoise/signals.py
@@ -141,6 +141,24 @@ def synthesize(graph, agent_id: int, signal: dict, model=default_model) -> str:
     return text
 
 
+def contact(graph, agent_id: int, signal: dict, send,
+            model=default_model) -> str:
+    """Reach out about a grounded signal, in character, through a medium.
+
+    Synthesizes a first-person event from the signal (Task 39) and sends it as
+    the opening message through `send`, the agent's active medium (e.g. a bound
+    `send_mail`) — the conversation-starter path, now graph-driven. The event
+    text is already the persona's own life, so it is the message. Returns the
+    text sent, or '' when synthesis drafts nothing (so nothing is sent). `send`
+    and `model` are injected so the outreach stays testable.
+    """
+    text = synthesize(graph, agent_id, signal, model=model)
+    if not text:
+        return ''
+    send(text)
+    return text
+
+
 if __name__ == '__main__':
     xmas = calendar_signal(date(2026, 12, 25))
     assert xmas['topic'] == 'calendar'

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -6,6 +6,7 @@ from datetime import date
 from françoise.graph import open_graph
 from françoise.signals import (
     calendar_signal,
+    contact,
     ground_signals,
     region_signals,
     synthesize,
@@ -188,6 +189,41 @@ class TestSynthesize(unittest.TestCase):
                 'SELECT ?e WHERE { GRAPH <%s> { ?e <%s> ?t } }'
                 % (synthetic, SCHEMA_PREDICATES['name'])))
             self.assertEqual(len(rows), 1)
+
+
+class TestContact(unittest.TestCase):
+    def setUp(self):
+        self.path = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.path)
+
+    def test_sends_the_event_as_the_opening_message(self):
+        signal = {'topic': 'cinema', 'place': 'Paris', 'note': 'a new film'}
+        event = 'I went to see the new film in Paris.'
+        model = lambda persona, past, s: event
+        sent = []
+        with open_graph(self.path) as graph:
+            graph.seed_persona(1, 'Boku', interests=['cinema'])
+            grounded = ground_signals(graph, 1, [signal])
+
+            text = contact(graph, 1, grounded[0], send=sent.append, model=model)
+
+        # The opening message is the persona's own first-person event, sent.
+        self.assertEqual(text, event)
+        self.assertEqual(sent, [event])
+
+    def test_nothing_is_sent_when_synthesis_drafts_nothing(self):
+        signal = {'topic': 'cinema', 'place': 'Paris'}
+        model = lambda persona, past, s: ''
+        sent = []
+        with open_graph(self.path) as graph:
+            graph.seed_persona(1, 'Boku', interests=['cinema'])
+
+            text = contact(graph, 1, signal, send=sent.append, model=model)
+
+        self.assertEqual(text, '')
+        self.assertEqual(sent, [])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Reach out about a grounded signal in character: synthesize a first-person
event and send it as the opening message through the agent's active medium,
reusing the conversation-starter path. The event text is the persona's own
life, so it is the message. Send is injected so outreach stays testable.

Closes #48
