### PR TITLE
Gate outreach by presence (#49)

### DIFF
--- a/françoise/signals.py
+++ b/françoise/signals.py
@@ -9,6 +9,8 @@ from datetime import date, datetime
 
 import requests
 
+from .presence import is_free
+
 OPEN_METEO_URL = 'https://api.open-meteo.com/v1/forecast'
 
 # ponytail: fixed-date holidays only; add a lib (e.g. `holidays`) if moving
@@ -142,16 +144,22 @@ def synthesize(graph, agent_id: int, signal: dict, model=default_model) -> str:
 
 
 def contact(graph, agent_id: int, signal: dict, send,
-            model=default_model) -> str:
+            model=default_model, agent: dict = None) -> str:
     """Reach out about a grounded signal, in character, through a medium.
 
     Synthesizes a first-person event from the signal (Task 39) and sends it as
     the opening message through `send`, the agent's active medium (e.g. a bound
     `send_mail`) — the conversation-starter path, now graph-driven. The event
     text is already the persona's own life, so it is the message. Returns the
-    text sent, or '' when synthesis drafts nothing (so nothing is sent). `send`
-    and `model` are injected so the outreach stays testable.
+    text sent, or '' when synthesis drafts nothing (so nothing is sent).
+
+    Outreach only lands in a persona's waking hours: when `agent` (its
+    persona dict, carrying `timezone`/`age`) is given and the persona is not
+    free (asleep or at school), nothing is sent. `send`, `model`, and `agent`
+    are injected so the outreach stays testable.
     """
+    if agent is not None and not is_free(agent):
+        return ''
     text = synthesize(graph, agent_id, signal, model=model)
     if not text:
         return ''

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -2,6 +2,7 @@ import shutil
 import tempfile
 import unittest
 from datetime import date
+from unittest.mock import patch
 
 from françoise.graph import open_graph
 from françoise.signals import (
@@ -224,6 +225,41 @@ class TestContact(unittest.TestCase):
 
         self.assertEqual(text, '')
         self.assertEqual(sent, [])
+
+    def test_nothing_is_sent_at_a_sleep_time(self):
+        signal = {'topic': 'cinema', 'place': 'Paris', 'note': 'a new film'}
+        event = 'I went to see the new film in Paris.'
+        model = lambda persona, past, s: event
+        sent = []
+        # 02:00 UTC: the child persona is asleep, so outreach holds.
+        agent = {'timezone': 'UTC', 'age': 10}
+        with open_graph(self.path) as graph, \
+                patch('françoise.signals.is_free', return_value=False):
+            graph.seed_persona(1, 'Boku', interests=['cinema'])
+            grounded = ground_signals(graph, 1, [signal])
+
+            text = contact(graph, 1, grounded[0], send=sent.append,
+                           model=model, agent=agent)
+
+        self.assertEqual(text, '')
+        self.assertEqual(sent, [])
+
+    def test_sends_in_a_free_window(self):
+        signal = {'topic': 'cinema', 'place': 'Paris', 'note': 'a new film'}
+        event = 'I went to see the new film in Paris.'
+        model = lambda persona, past, s: event
+        sent = []
+        agent = {'timezone': 'UTC', 'age': 10}
+        with open_graph(self.path) as graph, \
+                patch('françoise.signals.is_free', return_value=True):
+            graph.seed_persona(1, 'Boku', interests=['cinema'])
+            grounded = ground_signals(graph, 1, [signal])
+
+            text = contact(graph, 1, grounded[0], send=sent.append,
+                           model=model, agent=agent)
+
+        self.assertEqual(text, event)
+        self.assertEqual(sent, [event])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Send outreach only in a persona's waking hours: contact() now takes an
optional agent dict and holds the send when the persona is not free
(asleep or at school).
