### PR TITLE
Add eval harness (task 42)

### DIFF
--- a/evals/fixtures/smoke.json
+++ b/evals/fixtures/smoke.json
@@ -1,0 +1,4 @@
+[
+  {"input": "Say bonjour", "expected": "Bonjour"},
+  {"input": "Say merci", "expected": "Merci"}
+]

--- a/evals/harness.py
+++ b/evals/harness.py
@@ -1,0 +1,55 @@
+"""Minimal eval harness: run fixtures against a model config, record a score.
+
+A fixture is a JSON list of cases; each case is `{"input": str, "expected": str}`.
+`run` sends each input through the Provider under the given config and scores the
+reply. The default score is exact match; later evals pass their own `score` fn.
+"""
+import json
+import sys
+from collections.abc import Callable, Sequence
+
+from françoise.chat import Provider
+
+
+def load_fixtures(path: str) -> list[dict]:
+    """Load a JSON fixture file into a list of cases."""
+    with open(path) as f:
+        return json.load(f)
+
+
+def exact_match(reply: str, expected: str) -> float:
+    """Score 1.0 on an exact (trimmed) match, else 0.0."""
+    return 1.0 if reply.strip() == expected.strip() else 0.0
+
+
+def run(
+        cases: Sequence[dict],
+        config: dict,
+        score: Callable[[str, str], float] = exact_match,
+        provider: Provider = None) -> float:
+    """Run each case through the config and return the mean score."""
+    provider = provider or Provider()
+    if not cases:
+        return 0.0
+    total = 0.0
+    for case in cases:
+        reply = provider.chat(
+            [{'role': 'user', 'content': case['input']}], **config)
+        total += score(reply, case['expected'])
+    return total / len(cases)
+
+
+def main(argv: Sequence[str] = None) -> int:
+    """CLI: `python -m evals.harness <fixtures.json> <model>` prints the score."""
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if len(argv) != 2:
+        print('usage: python -m evals.harness <fixtures.json> <model>')
+        return 1
+    fixtures_path, model = argv
+    score = run(load_fixtures(fixtures_path), {'model': model})
+    print('score: %.3f' % score)
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -1,0 +1,46 @@
+import io
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+from evals.harness import exact_match, load_fixtures, main, run
+
+
+class FakeProvider:
+    def __init__(self, reply):
+        self.reply = reply
+
+    def chat(self, messages, **kwargs):
+        return self.reply
+
+
+class TestHarness(unittest.TestCase):
+    def test_load_fixtures_reads_smoke_cases(self):
+        cases = load_fixtures('evals/fixtures/smoke.json')
+        self.assertEqual(len(cases), 2)
+        self.assertEqual(cases[0]['input'], 'Say bonjour')
+
+    def test_run_scores_all_correct(self):
+        cases = [{'input': 'x', 'expected': 'Bonjour'}]
+        score = run(cases, {'model': 'test'}, provider=FakeProvider('Bonjour'))
+        self.assertEqual(score, 1.0)
+
+    def test_run_scores_wrong_reply(self):
+        cases = [{'input': 'x', 'expected': 'Bonjour'}]
+        score = run(cases, {'model': 'test'}, provider=FakeProvider('Salut'))
+        self.assertEqual(score, 0.0)
+
+    def test_exact_match_trims_whitespace(self):
+        self.assertEqual(exact_match('  Bonjour \n', 'Bonjour'), 1.0)
+
+    def test_main_prints_a_score(self):
+        with patch('evals.harness.Provider', return_value=FakeProvider('Bonjour')):
+            out = io.StringIO()
+            with redirect_stdout(out):
+                code = main(['evals/fixtures/smoke.json', 'test-model'])
+        self.assertEqual(code, 0)
+        self.assertIn('score:', out.getvalue())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Load JSON fixtures, run a model config through the Provider, and print a
mean score. Default scoring is exact match; later evals pass their own
score fn. Closes #50.
