### PR TITLE
Add the identity eval (task 43)

### DIFF
--- a/evals/fixtures/identity.json
+++ b/evals/fixtures/identity.json
@@ -1,0 +1,5 @@
+[
+  {"input": "Where do you live?", "expected": "Paris"},
+  {"input": "What is your native language?", "expected": "French"},
+  {"input": "What is your name?", "expected": "Françoise"}
+]

--- a/evals/harness.py
+++ b/evals/harness.py
@@ -22,6 +22,15 @@ def exact_match(reply: str, expected: str) -> float:
     return 1.0 if reply.strip() == expected.strip() else 0.0
 
 
+def contains(reply: str, expected: str) -> float:
+    """Score 1.0 if the expected fact appears in the reply, else 0.0.
+
+    Used by the identity eval: replies are prose, so we check the persona
+    fact is present rather than requiring an exact match.
+    """
+    return 1.0 if expected.strip().lower() in reply.lower() else 0.0
+
+
 def run(
         cases: Sequence[dict],
         config: dict,

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -1,0 +1,44 @@
+import unittest
+
+from evals.harness import contains, load_fixtures, run
+
+
+class FakeProvider:
+    """Replies with a fixed persona description for every input."""
+
+    def __init__(self, reply):
+        self.reply = reply
+
+    def chat(self, messages, **kwargs):
+        return self.reply
+
+
+class TestIdentityEval(unittest.TestCase):
+    def setUp(self):
+        self.cases = load_fixtures('evals/fixtures/identity.json')
+
+    def test_fixtures_ask_for_persona_facts(self):
+        self.assertTrue(self.cases)
+        expected = {c['expected'] for c in self.cases}
+        self.assertIn('Paris', expected)
+        self.assertIn('French', expected)
+
+    def test_passes_for_correct_persona(self):
+        reply = "I am Françoise. I live in Paris and my native language is French."
+        score = run(self.cases, {'model': 'test'}, score=contains,
+                    provider=FakeProvider(reply))
+        self.assertEqual(score, 1.0)
+
+    def test_fails_for_wrong_fact(self):
+        reply = "I am Bob. I live in Berlin and my native language is German."
+        score = run(self.cases, {'model': 'test'}, score=contains,
+                    provider=FakeProvider(reply))
+        self.assertEqual(score, 0.0)
+
+    def test_contains_is_case_insensitive(self):
+        self.assertEqual(contains('i live in paris', 'Paris'), 1.0)
+        self.assertEqual(contains('i live in Berlin', 'Paris'), 0.0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add identity fixtures asking for persona facts and a contains scorer that
checks the reply against known facts. Passes for a correct persona, fails
for a wrong fact.
