### PR TITLE
Add the CEFR eval (Task 44)

### DIFF
--- a/evals/fixtures/cefr.json
+++ b/evals/fixtures/cefr.json
@@ -1,0 +1,8 @@
+[
+  {"input": "Reply at CEFR level A1.", "expected": "A1"},
+  {"input": "Reply at CEFR level A2.", "expected": "A2"},
+  {"input": "Reply at CEFR level B1.", "expected": "B1"},
+  {"input": "Reply at CEFR level B2.", "expected": "B2"},
+  {"input": "Reply at CEFR level C1.", "expected": "C1"},
+  {"input": "Reply at CEFR level C2.", "expected": "C2"}
+]

--- a/evals/harness.py
+++ b/evals/harness.py
@@ -5,10 +5,13 @@ A fixture is a JSON list of cases; each case is `{"input": str, "expected": str}
 reply. The default score is exact match; later evals pass their own `score` fn.
 """
 import json
+import re
 import sys
 from collections.abc import Callable, Sequence
 
 from françoise.chat import Provider
+
+CEFR_LEVELS = ('A1', 'A2', 'B1', 'B2', 'C1', 'C2')
 
 
 def load_fixtures(path: str) -> list[dict]:
@@ -29,6 +32,29 @@ def contains(reply: str, expected: str) -> float:
     fact is present rather than requiring an exact match.
     """
     return 1.0 if expected.strip().lower() in reply.lower() else 0.0
+
+
+def cefr_level(reply: str) -> str:
+    """Estimate a reply's CEFR level from its mean words-per-sentence.
+
+    ponytail: sentence-length heuristic bucketed into the six levels — no
+    external readability dep. Swap for a scored classifier if replies get
+    mis-levelled in practice.
+    """
+    sentences = [s for s in re.split(r'[.!?]+', reply) if s.strip()]
+    words = reply.split()
+    if not sentences or not words:
+        return 'A1'
+    wps = len(words) / len(sentences)
+    for level, ceiling in zip(CEFR_LEVELS, (6, 9, 12, 16, 20, float('inf'))):
+        if wps <= ceiling:
+            return level
+    return 'C2'
+
+
+def level_fit(reply: str, expected: str) -> float:
+    """Score 1.0 when the reply's estimated CEFR level matches `expected`."""
+    return 1.0 if cefr_level(reply) == expected.strip().upper() else 0.0
 
 
 def run(

--- a/tests/test_cefr.py
+++ b/tests/test_cefr.py
@@ -1,0 +1,51 @@
+import unittest
+
+from evals.harness import CEFR_LEVELS, cefr_level, level_fit, load_fixtures, run
+
+
+class LevelledProvider:
+    """Replies with a fixed sentence-length band per input target level."""
+
+    # Word counts per sentence chosen to land mid-bucket for each level.
+    _reply = {
+        'A1': ' '.join(['word'] * 4) + '.',    # wps 4  -> A1 (<=6)
+        'A2': ' '.join(['word'] * 8) + '.',    # wps 8  -> A2 (<=9)
+        'B1': ' '.join(['word'] * 11) + '.',   # wps 11 -> B1 (<=12)
+        'B2': ' '.join(['word'] * 14) + '.',   # wps 14 -> B2 (<=16)
+        'C1': ' '.join(['word'] * 18) + '.',   # wps 18 -> C1 (<=20)
+        'C2': ' '.join(['word'] * 24) + '.',   # wps 24 -> C2 (>20)
+    }
+
+    def chat(self, messages, **kwargs):
+        target = messages[-1]['content'].strip().rstrip('.').split()[-1]
+        return self._reply[target]
+
+
+class TestCefrEval(unittest.TestCase):
+    def setUp(self):
+        self.cases = load_fixtures('evals/fixtures/cefr.json')
+
+    def test_fixtures_cover_every_level(self):
+        expected = [c['expected'] for c in self.cases]
+        self.assertEqual(expected, list(CEFR_LEVELS))
+
+    def test_cefr_level_buckets_by_sentence_length(self):
+        self.assertEqual(cefr_level('I like cats.'), 'A1')
+        long = ' '.join(['word'] * 30) + '.'
+        self.assertEqual(cefr_level(long), 'C2')
+
+    def test_cefr_level_empty_reply(self):
+        self.assertEqual(cefr_level(''), 'A1')
+
+    def test_level_fit_matches_expected(self):
+        self.assertEqual(level_fit('I like cats.', 'A1'), 1.0)
+        self.assertEqual(level_fit('I like cats.', 'C2'), 0.0)
+
+    def test_run_scores_each_level(self):
+        score = run(self.cases, {'model': 'test'}, score=level_fit,
+                    provider=LevelledProvider())
+        self.assertEqual(score, 1.0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Score replies for CEFR level fit A1-C2. Add a per-level fixture set and
a level_fit scorer that estimates a reply's level from mean
words-per-sentence and compares it to the target level.

Closes #52
