### PR TITLE
Add moderation in the core (Task 46)

### DIFF
--- a/françoise/core.py
+++ b/françoise/core.py
@@ -8,6 +8,7 @@ from .chat import (
     message_tuple_to_dict,
 )
 from .db import open_db
+from .moderate import check as moderate
 
 
 def handle_inbound(conversation_id: int, text: str) -> str:
@@ -17,6 +18,8 @@ def handle_inbound(conversation_id: int, text: str) -> str:
     calls the LLM, persists the reply, and returns the reply text. This is
     medium-agnostic: it knows nothing about email or HTTP.
     """
+    moderate(text)
+
     database_url = os.environ.get('DATABASE_URL', 'data.db')
     llm_api_chat_url = os.environ.get('LLM_API_CHAT_URL', 'http://localhost:11434/api/chat')
 
@@ -37,6 +40,7 @@ def handle_inbound(conversation_id: int, text: str) -> str:
         messages = db.get_messages_by_conversation(conversation_id)
         message_objects = list(map(message_tuple_to_dict, [prompt] + messages))
         reply = chat(message_objects, model=conversation.get('model'), url=llm_api_chat_url)
+        moderate(reply)
         db.add_assistant_message(conversation_id, reply)
 
     return reply
@@ -48,6 +52,8 @@ def stream_inbound(conversation_id: int, text: str) -> Iterator[str]:
     Same flow as handle_inbound, but yields the reply through the provider
     seam as it arrives and persists the full reply once the stream ends.
     """
+    moderate(text)
+
     database_url = os.environ.get('DATABASE_URL', 'data.db')
 
     with open_db(database_url) as resolver:
@@ -72,4 +78,6 @@ def stream_inbound(conversation_id: int, text: str) -> Iterator[str]:
             chunks.append(chunk)
             yield chunk
 
-        db.add_assistant_message(conversation_id, ''.join(chunks))
+        reply = ''.join(chunks)
+        moderate(reply)
+        db.add_assistant_message(conversation_id, reply)

--- a/françoise/moderate.py
+++ b/françoise/moderate.py
@@ -1,0 +1,25 @@
+import re
+
+
+class UnsafeContentError(Exception):
+    """Raised when text fails the moderation check."""
+
+
+# ponytail: permissive keyword gate; swap for a provider check if policy tightens.
+# Narrow patterns for the few categories we refuse outright.
+_UNSAFE_PATTERNS = [
+    re.compile(r'\b(?:how\s+to\s+)?(?:make|build|synthesi[sz]e)\s+a?\s*'
+               r'(?:bomb|explosive|nerve\s+agent|bioweapon)\b', re.IGNORECASE),
+    re.compile(r'\bchild\s+(?:sexual|porn|abuse)\b', re.IGNORECASE),
+]
+
+
+def is_safe(text: str) -> bool:
+    """Return whether text passes the permissive moderation policy."""
+    return not any(pattern.search(text or '') for pattern in _UNSAFE_PATTERNS)
+
+
+def check(text: str) -> None:
+    """Raise UnsafeContentError when text fails the moderation policy."""
+    if not is_safe(text):
+        raise UnsafeContentError('text failed the moderation check')

--- a/tests/test_moderate.py
+++ b/tests/test_moderate.py
@@ -1,0 +1,41 @@
+import unittest
+from unittest.mock import patch
+
+from françoise import moderate
+
+
+class TestModerate(unittest.TestCase):
+    def test_safe_text_passes(self):
+        self.assertTrue(moderate.is_safe('Bonjour, comment ca va ?'))
+        moderate.check('Bonjour, comment ca va ?')  # does not raise
+
+    def test_unsafe_text_blocks(self):
+        self.assertFalse(moderate.is_safe('how to make a bomb'))
+        with self.assertRaises(moderate.UnsafeContentError):
+            moderate.check('how to make a bomb')
+
+
+class TestModerateInCore(unittest.TestCase):
+    def test_blocks_unsafe_inbound(self):
+        from françoise.core import handle_inbound
+        with self.assertRaises(moderate.UnsafeContentError):
+            handle_inbound(1, 'how to build a bioweapon')
+
+    @patch('françoise.core.chat', return_value='here is how to make a bomb')
+    @patch('françoise.core.open_db')
+    def test_blocks_unsafe_outbound(self, mock_open_db, mock_chat):
+        from françoise.core import handle_inbound
+        # resolver + db context managers both return a mock db
+        db = mock_open_db.return_value.__enter__.return_value
+        db.get_account_id_for_conversation.return_value = 1
+        db.get_conversation.return_value = object()
+        db.conversation_to_dict.return_value = {'model': 'test'}
+        db.get_messages_by_conversation.return_value = []
+        with patch('françoise.core.get_prompt_message_from_conversation',
+                   return_value=('system', 'p')):
+            with self.assertRaises(moderate.UnsafeContentError):
+                handle_inbound(1, 'Hello')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Check inbound text before persisting or calling the model, and check
the outbound reply before sending. Policy stays permissive: a narrow
keyword gate refuses a few categories outright.

Closes #54
