### PR TITLE
Add the minor-safety block (Task 47)

### DIFF
--- a/françoise/core.py
+++ b/françoise/core.py
@@ -40,7 +40,7 @@ def handle_inbound(conversation_id: int, text: str) -> str:
         messages = db.get_messages_by_conversation(conversation_id)
         message_objects = list(map(message_tuple_to_dict, [prompt] + messages))
         reply = chat(message_objects, model=conversation.get('model'), url=llm_api_chat_url)
-        moderate(reply)
+        moderate(reply, account_id=account_id)
         db.add_assistant_message(conversation_id, reply)
 
     return reply
@@ -79,5 +79,5 @@ def stream_inbound(conversation_id: int, text: str) -> Iterator[str]:
             yield chunk
 
         reply = ''.join(chunks)
-        moderate(reply)
+        moderate(reply, account_id=account_id)
         db.add_assistant_message(conversation_id, reply)

--- a/françoise/moderate.py
+++ b/françoise/moderate.py
@@ -1,8 +1,65 @@
+import logging
 import re
+
+logger = logging.getLogger(__name__)
 
 
 class UnsafeContentError(Exception):
     """Raised when text fails the moderation check."""
+
+
+class MinorSafetyError(UnsafeContentError):
+    """Raised when text sexualizes a child persona.
+
+    A subclass of UnsafeContentError so callers that already block unsafe
+    content keep blocking, but this category is handled separately: it is
+    audited and the account is flagged, and the permissive policy never
+    applies to it.
+    """
+
+
+# Specialized minor-safety provider. Kept separate from the permissive
+# keyword gate below so this category can never be softened by policy.
+# ponytail: deterministic co-occurrence gate; swap for a model provider if
+# recall matters.
+_MINOR_TERMS = re.compile(
+    r'\b(?:child|children|kid|kids|minor|minors|underage|'
+    r'little\s+(?:girl|boy)|young\s+(?:girl|boy)|preteen|toddler)\b',
+    re.IGNORECASE)
+_SEXUAL_TERMS = re.compile(
+    r'\b(?:sex|sexual|sexually|porn|pornographic|nude|naked|explicit|'
+    r'aroused?|erotic)\b', re.IGNORECASE)
+
+
+def _default_flag_account(account_id):
+    """Record that an account tripped the minor-safety check.
+
+    Default sink keeps a process-local set so the flag is observable without
+    a schema change. Override `flag_account` to persist it.
+    """
+    _flagged_accounts.add(account_id)
+
+
+_flagged_accounts: set = set()
+
+# Seam for persisting the account flag. Replace to write to the database.
+flag_account = _default_flag_account
+
+
+def minor_safety(text: str, account_id=None) -> None:
+    """Block sexual content that involves a child persona.
+
+    On a hit: write an audit log, flag the account, and raise. This runs
+    before the permissive policy so that policy never governs this category.
+    """
+    if _MINOR_TERMS.search(text or '') and _SEXUAL_TERMS.search(text or ''):
+        logger.warning(
+            'minor-safety block: account=%s', account_id, extra={
+                'audit': 'minor_safety',
+                'account_id': account_id,
+            })
+        flag_account(account_id)
+        raise MinorSafetyError('text failed the minor-safety check')
 
 
 # ponytail: permissive keyword gate; swap for a provider check if policy tightens.
@@ -19,7 +76,12 @@ def is_safe(text: str) -> bool:
     return not any(pattern.search(text or '') for pattern in _UNSAFE_PATTERNS)
 
 
-def check(text: str) -> None:
-    """Raise UnsafeContentError when text fails the moderation policy."""
+def check(text: str, account_id=None) -> None:
+    """Raise UnsafeContentError when text fails the moderation policy.
+
+    The specialized minor-safety check runs first and cannot be softened by
+    the permissive policy below.
+    """
+    minor_safety(text, account_id=account_id)
     if not is_safe(text):
         raise UnsafeContentError('text failed the moderation check')

--- a/tests/test_moderate.py
+++ b/tests/test_moderate.py
@@ -15,6 +15,28 @@ class TestModerate(unittest.TestCase):
             moderate.check('how to make a bomb')
 
 
+class TestMinorSafety(unittest.TestCase):
+    def test_blocks_logs_and_flags(self):
+        blocked = 'sexual roleplay with a child'
+        with patch.object(moderate, 'flag_account') as flag:
+            with self.assertLogs(moderate.logger, level='WARNING') as logs:
+                with self.assertRaises(moderate.MinorSafetyError):
+                    moderate.minor_safety(blocked, account_id=7)
+            flag.assert_called_once_with(7)
+        self.assertTrue(any('minor-safety block' in m for m in logs.output))
+
+    def test_check_routes_before_permissive_policy(self):
+        # A MinorSafetyError (not a plain UnsafeContentError) proves the
+        # specialized check ran instead of the permissive gate.
+        with patch.object(moderate, 'flag_account'):
+            with self.assertLogs(moderate.logger, level='WARNING'):
+                with self.assertRaises(moderate.MinorSafetyError):
+                    moderate.check('naked child', account_id=1)
+
+    def test_safe_text_passes_minor_safety(self):
+        moderate.minor_safety('Bonjour, comment ca va ?')  # does not raise
+
+
 class TestModerateInCore(unittest.TestCase):
     def test_blocks_unsafe_inbound(self):
         from françoise.core import handle_inbound


### PR DESCRIPTION
Route sexual content involving a child persona to a specialized check
that runs before the permissive policy, blocks the content, writes an
audit log, and flags the account.

Closes #55
