### PR TITLE
Add the age gate (Task 48)

### DIFF
--- a/françoise/app.py
+++ b/françoise/app.py
@@ -38,6 +38,20 @@ LOGIN_FORM = """<!DOCTYPE html>
 </html>
 """
 
+SIGNUP_FORM = """<!DOCTYPE html>
+<html lang="en">
+<body>
+    <form method="post" action="/signup">
+        <input type="text" name="name" required>
+        <input type="email" name="email" required>
+        <input type="password" name="password" required>
+        <label><input type="checkbox" name="over_18" value="yes"> I am 18 or older</label>
+        <button type="submit">Sign up</button>
+    </form>
+</body>
+</html>
+"""
+
 
 def reply_fragment(conversation_id: int, message: str) -> str:
     # OOB fragment that appends a reply to an open conversation's messages.
@@ -174,6 +188,30 @@ def App(**kwargs):
         response.set_cookie('session', session_id, httponly=True)
 
         return 'Logged in.'
+
+    @app.get('/signup', response_class=HTMLResponse)
+    def signup_form() -> str:
+        return SIGNUP_FORM
+
+    @app.post('/signup', response_class=HTMLResponse)
+    def signup(
+            name: Annotated[str, Form()],
+            email: Annotated[str, Form()],
+            password: Annotated[str, Form()],
+            response: Response,
+            over_18: Annotated[Optional[str], Form()] = None) -> str:
+        # Self-attested age gate: keep the product adults-only at launch.
+        if over_18 != 'yes':
+            response.status_code = status.HTTP_403_FORBIDDEN
+            return 'You must be 18 or older to sign up.'
+
+        password_hash = PasswordHasher().hash(password)
+        with open_db(DATABASE_URL) as db:
+            account = db.create_account(name)
+        with open_db(DATABASE_URL, account_id=account[0]) as db:
+            db.create_user(name, email, password_hash)
+
+        return 'Signed up.'
 
     def require_session(session: Annotated[Optional[str], Cookie()] = None):
         if session is not None:

--- a/tests/test_signup.py
+++ b/tests/test_signup.py
@@ -1,0 +1,49 @@
+import os
+import tempfile
+import unittest
+
+from fastapi.testclient import TestClient
+
+from françoise.app import App
+from françoise.db import open_db
+from françoise.migrate import upgrade_to_head
+
+
+class TestSignupRoutes(unittest.TestCase):
+    def setUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix='.db')
+        os.close(fd)
+
+        upgrade_to_head(self.db_path)
+
+        self.app = App(DATABASE_URL=self.db_path)
+        self.client = TestClient(self.app)
+
+    def tearDown(self):
+        os.remove(self.db_path)
+
+    def user_count(self) -> int:
+        with open_db(self.db_path) as db:
+            return db.connection.execute(
+                'SELECT COUNT(*) FROM users').fetchone()[0]
+
+    def test_over_18_completes_signup(self):
+        response = self.client.post('/signup', data={
+            'name': 'Alice',
+            'email': 'alice@example.com',
+            'password': 'correct horse',
+            'over_18': 'yes'})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.user_count(), 1)
+
+    def test_under_18_cannot_sign_up(self):
+        response = self.client.post('/signup', data={
+            'name': 'Bob',
+            'email': 'bob@example.com',
+            'password': 'correct horse'})
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(self.user_count(), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add a /signup route with a self-attested 18+ check that stops
signup when the user does not attest to being 18 or older.
