### PR TITLE
Verify the Mailgun webhook signature (#57)

### DIFF
--- a/françoise/app.py
+++ b/françoise/app.py
@@ -23,7 +23,7 @@ from fastapi.responses import HTMLResponse, StreamingResponse
 
 from .core import handle_inbound, stream_inbound
 from .db import open_db
-from .mail import parse_conversation_id_from_headers, send_mail
+from .mail import parse_conversation_id_from_headers, send_mail, verify_signature
 from .presence import is_free, presence_label, presence_local_time
 
 LOGIN_FORM = """<!DOCTYPE html>
@@ -296,7 +296,13 @@ def App(**kwargs):
             message: Annotated[str, Form(alias='body-plain')],
             sender: Annotated[str, Form()],
             subject: Annotated[str, Form()],
+            timestamp: Annotated[str, Form()],
+            token: Annotated[str, Form()],
+            signature: Annotated[str, Form()],
             background_tasks: BackgroundTasks) -> None:
+        if not verify_signature(
+                MAILGUN_API_KEY, timestamp, token, signature):
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
         background_tasks.add_task(
                 chat_and_reply,
                 headers,

--- a/françoise/mail.py
+++ b/françoise/mail.py
@@ -1,7 +1,22 @@
+import hashlib
+import hmac
 import re
 from typing import Optional
 
 import requests
+
+
+def verify_signature(
+        api_key: str, timestamp: str, token: str, signature: str) -> bool:
+    # Mailgun signs webhooks as HMAC-SHA256(timestamp + token) keyed with the
+    # API key. Reject when anything is missing or the digest does not match.
+    if not (api_key and timestamp and token and signature):
+        return False
+    expected = hmac.new(
+        key=api_key.encode(),
+        msg=(timestamp + token).encode(),
+        digestmod=hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, signature)
 
 
 def parse_to_header(headers: str) -> Optional[str]:

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -1,6 +1,19 @@
+import hashlib
+import hmac
 import unittest
 
-from françoise.mail import parse_to_header, parse_conversation_id_from_headers
+from françoise.mail import (
+    parse_to_header,
+    parse_conversation_id_from_headers,
+    verify_signature,
+)
+
+
+def sign(api_key: str, timestamp: str, token: str) -> str:
+    return hmac.new(
+        key=api_key.encode(),
+        msg=(timestamp + token).encode(),
+        digestmod=hashlib.sha256).hexdigest()
 
 
 class TestMail(unittest.TestCase):
@@ -13,6 +26,16 @@ class TestMail(unittest.TestCase):
         headers = '[["To","\"Boku.2\" <foo@bar.com>"]]'
         conversation_id = parse_conversation_id_from_headers(headers)
         self.assertEqual(conversation_id, 2)
+
+    def test_verify_signature_valid(self):
+        signature = sign('key', '12345', 'abc')
+        self.assertTrue(verify_signature('key', '12345', 'abc', signature))
+
+    def test_verify_signature_forged(self):
+        self.assertFalse(verify_signature('key', '12345', 'abc', 'deadbeef'))
+
+    def test_verify_signature_missing_fields(self):
+        self.assertFalse(verify_signature('key', '', '', ''))
 
 
 if __name__ == '__main__':

--- a/tests/test_mailgun.py
+++ b/tests/test_mailgun.py
@@ -1,0 +1,64 @@
+import hashlib
+import hmac
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from françoise.app import App
+from françoise.migrate import upgrade_to_head
+
+API_KEY = 'signing-key'
+
+
+def sign(timestamp: str, token: str) -> str:
+    return hmac.new(
+        key=API_KEY.encode(),
+        msg=(timestamp + token).encode(),
+        digestmod=hashlib.sha256).hexdigest()
+
+
+class TestMailgunRoute(unittest.TestCase):
+    def setUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix='.db')
+        os.close(fd)
+        upgrade_to_head(self.db_path)
+        self.app = App(DATABASE_URL=self.db_path, MAILGUN_API_KEY=API_KEY)
+        self.client = TestClient(self.app)
+
+    def tearDown(self):
+        os.remove(self.db_path)
+
+    def _payload(self, timestamp, token, signature):
+        return {
+            'message-headers': '[["To","\"Boku.1\" <foo@bar.com>"]]',
+            'body-plain': 'Bonjour',
+            'sender': 'alice@example.com',
+            'subject': 'Salut',
+            'timestamp': timestamp,
+            'token': token,
+            'signature': signature,
+        }
+
+    def test_valid_signature_passes(self):
+        # stub the scheduled work so a valid post does not run the real reply
+        with patch('fastapi.BackgroundTasks.add_task') as mock_add_task:
+            response = self.client.post(
+                '/mailgun',
+                data=self._payload('12345', 'abc', sign('12345', 'abc')))
+        self.assertEqual(response.status_code, 200)
+        mock_add_task.assert_called_once()
+
+    def test_forged_signature_rejected(self):
+        with patch('fastapi.BackgroundTasks.add_task') as mock_add_task:
+            response = self.client.post(
+                '/mailgun',
+                data=self._payload('12345', 'abc', 'forged'))
+        self.assertEqual(response.status_code, 401)
+        mock_add_task.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Reject forged webhooks with a 401 by checking the HMAC-SHA256 signature
over timestamp+token, keyed with the Mailgun API key, before scheduling
any processing.
