### PR TITLE
Fix 4 integration failures (green suite on rewrite/base)

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -15,9 +15,11 @@ database_url = os.environ.get("DATABASE_URL", "data.db")
 config.set_main_option("sqlalchemy.url", "sqlite:///%s" % database_url)
 
 # Interpret the config file for Python logging.
-# This line sets up loggers basically.
+# disable_existing_loggers=False so running migrations never silences the
+# application's already-configured loggers (e.g. françoise.moderate). The
+# default (True) disables every logger that exists at config time.
 if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+    fileConfig(config.config_file_name, disable_existing_loggers=False)
 
 # add your model's MetaData object here
 # for 'autogenerate' support

--- a/tests/test_defer.py
+++ b/tests/test_defer.py
@@ -73,9 +73,13 @@ class TestDeferReply(unittest.TestCase):
         with patch('françoise.app.is_free', side_effect=lambda *a: next(states)):
             self._post()
 
-        # The reply reached the stream once the persona was free.
+        # The reply reached the stream once the persona was free. The stream
+        # also carries a presence-refresh fragment, so scan all fragments.
         self.assertFalse(channel.empty())
-        self.assertIn('Bonjour !', channel.get_nowait())
+        fragments = []
+        while not channel.empty():
+            fragments.append(channel.get_nowait())
+        self.assertTrue(any('Bonjour !' in f for f in fragments))
 
 
 if __name__ == '__main__':

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -63,12 +63,15 @@ class TestMessageRoute(unittest.TestCase):
         while not channel.empty():
             fragments.append(channel.get_nowait())
 
-        self.assertEqual(len(fragments), 3)
-        for fragment in fragments:
-            self.assertIn('id="messages-%d"' % conversation_id, fragment)
+        # the stream also carries a presence-refresh fragment; the reply
+        # itself arrives as message fragments, one per chunk.
+        message_fragments = [
+            f for f in fragments
+            if 'id="messages-%d"' % conversation_id in f]
+        self.assertEqual(len(message_fragments), 3)
         self.assertEqual(
             ''.join(re.search(r'<div>(.*)</div></div>', f).group(1)
-                    for f in fragments),
+                    for f in message_fragments),
             'Salut !')
 
 


### PR DESCRIPTION
Brings the integrated `rewrite/base` from 103/107 to **107/107**.

## Root causes
1. **`migrations/env.py` disabled application loggers.** `fileConfig()` defaults to `disable_existing_loggers=True`, so every test that builds a migrated DB silenced `françoise.moderate`, breaking its two `assertLogs(WARNING)` tests. Also a real production bug: running migrations at startup would silence app logging. Fixed with `disable_existing_loggers=False`.
2. **Stale presence-fragment assertions.** Task 34 legitimately pushes a presence-refresh OOB fragment onto the per-user channel (the plan's 'presence updates over the SSE stream' design). `test_message` and `test_defer` predate it and assumed the channel held only reply fragments. Updated to assert on the message fragments specifically, intent intact.

## Verification
`python -m unittest discover -s tests` → **Ran 107 tests, OK** (verified with core `fastapi` + alembic/pyoxigraph/anthropic/litellm in a scratch venv, since `fastapi[standard]` can't build here).

Follow-ups (not in this PR): land `model_configs` + provider wiring (PR #80), and swap the `fastapi[standard]` pin — both need a buildable env.