### PR TITLE
Land model_configs and wire the provider (resolve #80)

### DIFF
--- a/françoise/db.py
+++ b/françoise/db.py
@@ -34,18 +34,35 @@ tables = [
     ),
 
     (
+        'model_configs',
+        [
+            ('id', 'INTEGER PRIMARY KEY AUTOINCREMENT'),
+            ('dialect', 'TEXT'),
+            ('host', 'TEXT'),
+            ('endpoint', 'TEXT'),
+            ('model_id', 'TEXT NOT NULL'),
+            ('params', 'TEXT'),
+            ('credential_ref', 'TEXT')
+        ],
+        [
+            'UNIQUE(model_id)'
+        ]
+    ),
+
+    (
         'conversations',
         [
             ('id', 'INTEGER PRIMARY KEY AUTOINCREMENT'),
             ('user_id', 'INTEGER NOT NULL'),
             ('agent_id', 'INTEGER NOT NULL'),
-            ('model', 'TEXT NOT NULL'),
+            ('model_config_id', 'INTEGER NOT NULL'),
             ('proficiency', 'TEXT NOT NULL')
         ],
         [
-            'UNIQUE(model, user_id, agent_id)',
+            'UNIQUE(model_config_id, user_id, agent_id)',
             'FOREIGN KEY(user_id) REFERENCES users(id)',
-            'FOREIGN KEY(agent_id) REFERENCES agents(id)'
+            'FOREIGN KEY(agent_id) REFERENCES agents(id)',
+            'FOREIGN KEY(model_config_id) REFERENCES model_configs(id)'
         ]
     ),
 
@@ -201,6 +218,16 @@ class Database:
             self.connection.execute(
                 "DELETE FROM sessions WHERE id = ?", (id,))
 
+    def upsert_model_config(self, model_id: str) -> int:
+        # Reuse a config for the same model string rather than duplicating it.
+        with self.connection:
+            self.connection.execute(
+                "INSERT OR IGNORE INTO model_configs (model_id) VALUES (?)",
+                (model_id,))
+        res = self.connection.execute(
+            "SELECT id FROM model_configs WHERE model_id = ?", (model_id,))
+        return res.fetchone()[0]
+
     def create_conversation(
             self,
             user_id: int,
@@ -212,7 +239,7 @@ class Database:
                 user_id=user_id,
                 agent_id=agent_id,
                 proficiency=proficiency,
-                model=model)
+                model_config_id=self.upsert_model_config(model))
 
     def create_message(self, conversation_id: int, role: str, content: str):
         # messages are scoped through their conversation's account
@@ -238,7 +265,7 @@ class Database:
         res = self.connection.execute("""
             SELECT
                 conversation.id,
-                conversation.model,
+                model_config.model_id AS model,
                 conversation.user_id,
                 user.email AS user_email,
                 user.name AS user_name,
@@ -255,6 +282,8 @@ class Database:
             ON conversation.user_id = user.id
             JOIN agents agent
             ON conversation.agent_id = agent.id
+            JOIN model_configs model_config
+            ON conversation.model_config_id = model_config.id
             WHERE conversation.id = ?
             AND conversation.account_id = ?
         """, (id, self.require_account()))

--- a/migrations/versions/a7b8c9d0e1f2_add_model_configs_table.py
+++ b/migrations/versions/a7b8c9d0e1f2_add_model_configs_table.py
@@ -1,0 +1,104 @@
+"""add model_configs table and reference it from conversations
+
+Revision ID: a7b8c9d0e1f2
+Revises: f6a7b8c9d0e1
+Create Date: 2026-08-09 08:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a7b8c9d0e1f2'
+down_revision: Union[str, Sequence[str], None] = 'f6a7b8c9d0e1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS model_configs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dialect TEXT,
+            host TEXT,
+            endpoint TEXT,
+            model_id TEXT NOT NULL,
+            params TEXT,
+            credential_ref TEXT,
+            UNIQUE(model_id)
+        );
+    """)
+    # Backfill a model_config per distinct existing model string.
+    op.execute("""
+        INSERT INTO model_configs (model_id)
+        SELECT DISTINCT model FROM conversations;
+    """)
+    # SQLite cannot drop a column a table constraint references, so rebuild
+    # `conversations`, swapping the `model` string for a `model_config_id` FK.
+    op.execute("""
+        CREATE TABLE conversations_new (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            agent_id INTEGER NOT NULL,
+            model_config_id INTEGER NOT NULL,
+            proficiency TEXT NOT NULL,
+            account_id INTEGER REFERENCES accounts(id),
+            UNIQUE(model_config_id, user_id, agent_id),
+            FOREIGN KEY(user_id) REFERENCES users(id),
+            FOREIGN KEY(agent_id) REFERENCES agents(id),
+            FOREIGN KEY(model_config_id) REFERENCES model_configs(id)
+        );
+    """)
+    op.execute("""
+        INSERT INTO conversations_new
+            (id, user_id, agent_id, model_config_id, proficiency, account_id)
+        SELECT
+            conversation.id,
+            conversation.user_id,
+            conversation.agent_id,
+            model_config.id,
+            conversation.proficiency,
+            conversation.account_id
+        FROM conversations conversation
+        JOIN model_configs model_config
+        ON model_config.model_id = conversation.model;
+    """)
+    op.execute("DROP TABLE conversations;")
+    op.execute("ALTER TABLE conversations_new RENAME TO conversations;")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.execute("""
+        CREATE TABLE conversations_old (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            agent_id INTEGER NOT NULL,
+            model TEXT NOT NULL,
+            proficiency TEXT NOT NULL,
+            account_id INTEGER REFERENCES accounts(id),
+            UNIQUE(model, user_id, agent_id),
+            FOREIGN KEY(user_id) REFERENCES users(id),
+            FOREIGN KEY(agent_id) REFERENCES agents(id)
+        );
+    """)
+    op.execute("""
+        INSERT INTO conversations_old
+            (id, user_id, agent_id, model, proficiency, account_id)
+        SELECT
+            conversation.id,
+            conversation.user_id,
+            conversation.agent_id,
+            model_config.model_id,
+            conversation.proficiency,
+            conversation.account_id
+        FROM conversations conversation
+        JOIN model_configs model_config
+        ON model_config.id = conversation.model_config_id;
+    """)
+    op.execute("DROP TABLE conversations;")
+    op.execute("ALTER TABLE conversations_old RENAME TO conversations;")
+    op.execute("DROP TABLE IF EXISTS model_configs;")

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -47,6 +47,36 @@ class TestAccountScope(unittest.TestCase):
             with self.assertRaises(Exception):
                 db.create_user('Eve', 'eve@example.com', 'hash')
 
+    def test_model_round_trips_and_reuses_config(self):
+        with open_db(self.db_path, account_id=self.account_one) as db:
+            user = db.create_user('Carol', 'carol@example.com', 'hash')
+            agent = db.create_agent(
+                'Momo', 'French', 'A1', 'You are {agent_name}.')
+            other = db.create_agent(
+                'Nono', 'French', 'A2', 'You are {agent_name}.')
+            first = db.create_conversation(
+                user_id=user[0], agent_id=agent[0],
+                proficiency='A1', model='ollama/llama3')[0]
+            # A different agent keeps the UNIQUE key distinct while the same
+            # model string must still reuse the one model_config row.
+            second = db.create_conversation(
+                user_id=user[0], agent_id=other[0],
+                proficiency='A2', model='ollama/llama3')[0]
+
+            # The model string round-trips through the JOIN unchanged.
+            conversation = db.conversation_to_dict(db.get_conversation(first))
+            self.assertEqual(conversation['model'], 'ollama/llama3')
+
+            # Both conversations reference the same model_config row.
+            rows = db.connection.execute(
+                "SELECT model_config_id FROM conversations WHERE id IN (?, ?)",
+                (first, second)).fetchall()
+            self.assertEqual(rows[0][0], rows[1][0])
+            count = db.connection.execute(
+                "SELECT COUNT(*) FROM model_configs "
+                "WHERE model_id = 'ollama/llama3'").fetchone()[0]
+            self.assertEqual(count, 1)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
Replaces the `conversations.model` string with a `model_configs` table + `model_config_id` FK, backward-compatibly. Learns from PR #80's failure (which changed the schema but left the runtime broken and lost the model data).

## Changes
- **Migration `a7b8c9d0e1f2`** (chains off persona-fields head): creates `model_configs(id, dialect, host, endpoint, model_id, params, credential_ref)`; backfills one config per distinct existing `model` string; rebuilds `conversations` swapping `model` for a `model_config_id` FK and changing UNIQUE `(model, user_id, agent_id)` -> `(model_config_id, user_id, agent_id)`. Downgrade restores the `model` string from the joined config and drops the table.
- **db.py**: `create_conversation(..., model=...)` signature unchanged; internally upserts (reuses) a `model_configs` row for the model string and stores its id. `get_conversation` JOINs `model_configs` and aliases `model_id AS model` in the same tuple position, so `conversation_to_dict` keys/output are unchanged. Tables metadata updated.
- **No changes** to `core.py`, `chat.py`/provider, or the ~15 existing tests that pass `model=` / read `conversation['model']`.
- **One new test** (`test_model_round_trips_and_reuses_config`): model round-trips through the JOIN; a second conversation with the same model reuses the one config row.

## Validation
`python -m unittest discover -s tests` -> **Ran 108 tests, OK** (prior 107 + the new one). Migration upgrade (with backfill) and downgrade (model string restored) verified manually.

Closes #112.