### PR TITLE
Persona management UI: create/list friends and start a conversation (#118)

### DIFF
--- a/françoise/app.py
+++ b/françoise/app.py
@@ -6,6 +6,7 @@ import secrets
 import time
 from datetime import datetime, timedelta, timezone
 from typing import Annotated, Optional
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from argon2 import PasswordHasher
 from argon2.exceptions import VerifyMismatchError
@@ -20,12 +21,19 @@ from fastapi import (
     Response,
     status,
 )
-from fastapi.responses import HTMLResponse, StreamingResponse
+from fastapi.responses import HTMLResponse, RedirectResponse, StreamingResponse
+from fastapi.templating import Jinja2Templates
+
+from evals.harness import CEFR_LEVELS
 
 from .core import handle_inbound, stream_inbound
 from .db import open_db
+from .graph import open_graph
 from .mail import parse_conversation_id_from_headers, send_mail, verify_signature
+from .persona import build_persona_prompt
 from .presence import is_free, presence_label, presence_local_time
+
+TEMPLATES = Jinja2Templates(directory='templates')
 
 LOGIN_FORM = """<!DOCTYPE html>
 <html lang="en">
@@ -94,6 +102,8 @@ def App(**kwargs):
     MAILGUN_API_SENDER = get_config(kwargs, 'MAILGUN_API_SENDER')
     MAILGUN_API_URL = get_config(kwargs, 'MAILGUN_API_URL')
     SERVER_API_KEY = get_config(kwargs, 'SERVER_API_KEY')
+    GRAPH_PATH = get_config(kwargs, 'GRAPH_PATH', 'graph.db')
+    DEFAULT_MODEL = get_config(kwargs, 'DEFAULT_MODEL', 'ollama/llama3')
 
     # NOTE one message channel for each user, keyed by user id, so events
     # route to the right user instead of leaking through a shared queue.
@@ -241,8 +251,11 @@ def App(**kwargs):
         if session is not None:
             with open_db(DATABASE_URL) as db:
                 row = db.get_session(session)
-            if row is not None:
-                return row
+                if row is not None:
+                    # Resolve the owning account once and ride it on the row
+                    # (session[3]) so account-scoped routes need no re-lookup.
+                    account_id = db.get_account_id_for_user(row[1])
+                    return tuple(row) + (account_id,)
         raise HTTPException(
                 status_code=status.HTTP_307_TEMPORARY_REDIRECT,
                 headers={'Location': '/login'})
@@ -250,6 +263,99 @@ def App(**kwargs):
     @app.get('/', response_class=HTMLResponse)
     def home(session=Depends(require_session)) -> str:
         return 'Welcome.'
+
+    @app.get('/agents', response_class=HTMLResponse)
+    def list_agents(request: Request, session=Depends(require_session)):
+        with open_db(DATABASE_URL, account_id=session[3]) as db:
+            rows = db.list_agents()
+        agents = [
+            dict(zip(('id', 'name', 'language', 'proficiency', 'location'), r))
+            for r in rows]
+        return TEMPLATES.TemplateResponse(
+            request, 'agents_list.html', {'agents': agents})
+
+    @app.get('/agents/new', response_class=HTMLResponse)
+    def new_agent(request: Request, session=Depends(require_session)):
+        return TEMPLATES.TemplateResponse(
+            request, 'agents_new.html', {'cefr_levels': CEFR_LEVELS})
+
+    @app.post('/agents')
+    def create_agent(
+            request: Request,
+            name: Annotated[str, Form()],
+            native_language: Annotated[str, Form()],
+            language: Annotated[str, Form()],
+            proficiency: Annotated[str, Form()],
+            session=Depends(require_session),
+            location: Annotated[Optional[str], Form()] = None,
+            timezone: Annotated[Optional[str], Form()] = None,
+            interests: Annotated[Optional[str], Form()] = None,
+            age: Annotated[Optional[str], Form()] = None):
+        # Validate at the trust boundary before anything is persisted.
+        error = None
+        parsed_age = None
+        if proficiency not in CEFR_LEVELS:
+            error = 'Proficiency must be one of %s.' % ', '.join(CEFR_LEVELS)
+        elif timezone:
+            try:
+                ZoneInfo(timezone)
+            except (ZoneInfoNotFoundError, ValueError):
+                error = 'Timezone must be a valid IANA name.'
+        if error is None and age:
+            try:
+                parsed_age = int(age)
+            except ValueError:
+                error = 'Age must be a number.'
+
+        if error is not None:
+            return TEMPLATES.TemplateResponse(
+                request, 'agents_new.html',
+                {'cefr_levels': CEFR_LEVELS, 'error': error},
+                status_code=status.HTTP_400_BAD_REQUEST)
+
+        interest_list = [
+            i.strip() for i in (interests or '').split(',') if i.strip()]
+        interests_text = ', '.join(interest_list) or None
+
+        prompt = build_persona_prompt({
+            'name': name,
+            'native_language': native_language,
+            'location': location,
+            'timezone': timezone,
+            'interests': interests_text,
+            'age': parsed_age,
+        })
+
+        with open_db(DATABASE_URL, account_id=session[3]) as db:
+            agent = db.create_agent(
+                name, language, proficiency, prompt,
+                location=location,
+                timezone=timezone,
+                interests=interests_text,
+                age=parsed_age,
+                native_language=native_language)
+
+        # Seed the persona into the shared `real` graph via the existing helper.
+        with open_graph(GRAPH_PATH) as graph:
+            graph.seed_persona(agent[0], name, interests=interest_list)
+
+        return RedirectResponse(
+            '/agents', status_code=status.HTTP_303_SEE_OTHER)
+
+    @app.post('/agents/{id}/start')
+    def start_conversation(id: int, session=Depends(require_session)):
+        with open_db(DATABASE_URL, account_id=session[3]) as db:
+            agent = db.get_agent(id)
+            if agent is None:
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+            conversation = db.create_conversation(
+                user_id=session[1],
+                agent_id=id,
+                proficiency=agent[3],
+                model=DEFAULT_MODEL)
+        return RedirectResponse(
+            '/c/%d' % conversation[0],
+            status_code=status.HTTP_302_FOUND)
 
     @app.get('/stream')
     async def stream(request: Request, session=Depends(require_session)):

--- a/françoise/db.py
+++ b/françoise/db.py
@@ -165,18 +165,58 @@ class Database:
         row = res.fetchone()
         return row[0] if row else None
 
+    def get_account_id_for_user(self, user_id: int):
+        # Unscoped resolver: a session carries only the user id, so map it to
+        # its owning account before opening a scoped Database.
+        res = self.connection.execute(
+            "SELECT account_id FROM users WHERE id = ?", (user_id,))
+        row = res.fetchone()
+        return row[0] if row else None
+
     def create_agent(
             self,
             name: str,
             language: str,
             proficiency: str,
-            prompt: str) -> tuple:
+            prompt: str,
+            location: str = None,
+            timezone: str = None,
+            interests: str = None,
+            age: int = None,
+            native_language: str = None) -> tuple:
+        # Optional structured persona fields default to None so the existing
+        # 4-arg callers (provisioner, tests) keep working; only set columns
+        # that were given.
+        extra = {
+            'location': location,
+            'timezone': timezone,
+            'interests': interests,
+            'age': age,
+            'native_language': native_language,
+        }
         return self.table_insert(
                 'agents',
                 name=name,
                 language=language,
                 proficiency=proficiency,
-                prompt=prompt)
+                prompt=prompt,
+                **{k: v for k, v in extra.items() if v is not None})
+
+    def list_agents(self) -> list:
+        # Account-scoped list for the persona index (name, language, level,
+        # location).
+        res = self.connection.execute(
+            "SELECT id, name, language, proficiency, location FROM agents "
+            "WHERE account_id = ? ORDER BY id",
+            (self.require_account(),))
+        return res.fetchall()
+
+    def get_agent(self, id: int):
+        res = self.connection.execute(
+            "SELECT id, name, language, proficiency FROM agents "
+            "WHERE id = ? AND account_id = ?",
+            (id, self.require_account()))
+        return res.fetchone()
 
     def create_user(
             self,

--- a/templates/agents_list.html
+++ b/templates/agents_list.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Friends</title>
+    <script src="https://unpkg.com/htmx.org@2"></script>
+</head>
+<body>
+    <h1>Friends</h1>
+    <p><a href="/agents/new">Add a friend</a></p>
+    {% if agents %}
+    <ul>
+        {% for agent in agents %}
+        <li>
+            {{ agent.name }} — {{ agent.language }} ({{ agent.proficiency }})
+            {% if agent.location %}— {{ agent.location }}{% endif %}
+            <form method="post" action="/agents/{{ agent.id }}/start">
+                <button type="submit">Start conversation</button>
+            </form>
+        </li>
+        {% endfor %}
+    </ul>
+    {% else %}
+    <p>No friends yet.</p>
+    {% endif %}
+</body>
+</html>

--- a/templates/agents_new.html
+++ b/templates/agents_new.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Add a friend</title>
+    <script src="https://unpkg.com/htmx.org@2"></script>
+</head>
+<body>
+    <h1>Add a friend</h1>
+    {% if error %}<p>{{ error }}</p>{% endif %}
+    <form method="post" action="/agents">
+        <label>Name <input type="text" name="name" required></label>
+        <label>Native language <input type="text" name="native_language" required></label>
+        <label>Target language <input type="text" name="language" required></label>
+        <label>Proficiency
+            <select name="proficiency" required>
+                {% for level in cefr_levels %}
+                <option value="{{ level }}">{{ level }}</option>
+                {% endfor %}
+            </select>
+        </label>
+        <label>Location (lat, long) <input type="text" name="location"></label>
+        <label>Timezone (IANA) <input type="text" name="timezone" placeholder="Europe/Paris"></label>
+        <label>Interests (comma-separated) <input type="text" name="interests"></label>
+        <label>Age <input type="number" name="age" min="0"></label>
+        <button type="submit">Create</button>
+    </form>
+</body>
+</html>

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,152 @@
+import os
+import shutil
+import tempfile
+import unittest
+
+from argon2 import PasswordHasher
+from fastapi.testclient import TestClient
+
+from françoise.app import App
+from françoise.db import open_db
+from françoise.graph import open_graph
+from françoise.migrate import upgrade_to_head
+from françoise.vocab import GRAPHS, SCHEMA_PREDICATES, agent_iri
+
+
+class TestAgentRoutes(unittest.TestCase):
+    def setUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix='.db')
+        os.close(fd)
+        self.graph_path = tempfile.mkdtemp()
+
+        upgrade_to_head(self.db_path)
+        password_hash = PasswordHasher().hash('correct horse')
+        with open_db(self.db_path) as db:
+            account = db.create_account('Acme')
+        with open_db(self.db_path, account_id=account[0]) as db:
+            self.user = db.create_user(
+                'Alice', 'alice@example.com', password_hash)
+
+        self.app = App(
+            DATABASE_URL=self.db_path,
+            GRAPH_PATH=self.graph_path)
+        self.client = TestClient(self.app)
+        self._login()
+
+    def tearDown(self):
+        os.remove(self.db_path)
+        shutil.rmtree(self.graph_path)
+
+    def _login(self):
+        response = self.client.post('/login', data={
+            'email': 'alice@example.com',
+            'password': 'correct horse'})
+        self.assertEqual(response.status_code, 200)
+
+    def _valid_form(self, **overrides):
+        data = {
+            'name': 'Boku',
+            'native_language': 'English',
+            'language': 'French',
+            'proficiency': 'A1',
+            'location': '48.85, 2.35',
+            'timezone': 'Europe/Paris',
+            'interests': 'cinema, cooking',
+            'age': '10',
+        }
+        data.update(overrides)
+        return data
+
+    def test_get_new_shows_form(self):
+        response = self.client.get('/agents/new')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('<form', response.text)
+        # the CEFR select is populated
+        self.assertIn('A1', response.text)
+        self.assertIn('C2', response.text)
+
+    def test_create_persists_fields_seeds_graph_and_lists(self):
+        response = self.client.post(
+            '/agents', data=self._valid_form(), follow_redirects=False)
+        self.assertEqual(response.status_code, 303)
+        self.assertEqual(response.headers['location'], '/agents')
+
+        # The agent row has the structured fields set.
+        with open_db(self.db_path, account_id=1) as db:
+            rows = db.list_agents()
+            self.assertEqual(len(rows), 1)
+            agent_id = rows[0][0]
+            full = db.connection.execute(
+                'SELECT timezone, age, interests, location, native_language '
+                'FROM agents WHERE id = ?', (agent_id,)).fetchone()
+        self.assertEqual(full[0], 'Europe/Paris')
+        self.assertEqual(full[1], 10)
+        self.assertEqual(full[2], 'cinema, cooking')
+        self.assertEqual(full[3], '48.85, 2.35')
+        self.assertEqual(full[4], 'English')
+
+        # The persona's self quad is seeded into the real graph.
+        with open_graph(self.graph_path) as graph:
+            rows = list(graph.query(
+                'SELECT ?o WHERE { GRAPH <%s> { <%s> <%s> ?o } }'
+                % (GRAPHS['real'], agent_iri(agent_id),
+                   SCHEMA_PREDICATES['name'])))
+        self.assertEqual(str(rows[0]['o']), '"Boku"')
+
+        # GET /agents shows the new persona.
+        response = self.client.get('/agents')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('Boku', response.text)
+        self.assertIn('French', response.text)
+
+    def test_start_creates_conversation_and_redirects(self):
+        self.client.post('/agents', data=self._valid_form())
+        with open_db(self.db_path, account_id=1) as db:
+            agent_id = db.list_agents()[0][0]
+
+        response = self.client.post(
+            '/agents/%d/start' % agent_id, follow_redirects=False)
+        self.assertEqual(response.status_code, 302)
+
+        with open_db(self.db_path, account_id=1) as db:
+            row = db.connection.execute(
+                'SELECT id FROM conversations WHERE agent_id = ?',
+                (agent_id,)).fetchone()
+        self.assertIsNotNone(row)
+        self.assertEqual(response.headers['location'], '/c/%d' % row[0])
+
+    def test_invalid_cefr_is_rejected(self):
+        response = self.client.post(
+            '/agents', data=self._valid_form(proficiency='Z9'))
+        self.assertEqual(response.status_code, 400)
+        with open_db(self.db_path, account_id=1) as db:
+            self.assertEqual(len(db.list_agents()), 0)
+
+    def test_invalid_timezone_is_rejected(self):
+        response = self.client.post(
+            '/agents', data=self._valid_form(timezone='Not/AZone'))
+        self.assertEqual(response.status_code, 400)
+        with open_db(self.db_path, account_id=1) as db:
+            self.assertEqual(len(db.list_agents()), 0)
+
+    def test_non_numeric_age_is_rejected(self):
+        response = self.client.post(
+            '/agents', data=self._valid_form(age='ten'))
+        self.assertEqual(response.status_code, 400)
+        with open_db(self.db_path, account_id=1) as db:
+            self.assertEqual(len(db.list_agents()), 0)
+
+    def test_routes_require_session(self):
+        anon = TestClient(self.app)
+        for method, path in (
+                ('get', '/agents'),
+                ('get', '/agents/new'),
+                ('post', '/agents'),
+                ('post', '/agents/1/start')):
+            response = getattr(anon, method)(path, follow_redirects=False)
+            self.assertEqual(response.status_code, 307)
+            self.assertEqual(response.headers['location'], '/login')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Resolves #118.

## What

The first Web UI surface: a signed-in user can define a friend (persona) and start a conversation.

- `GET /agents` — account-scoped list of personas (name, target language, CEFR level, location).
- `GET /agents/new` — Jinja2 form: name, native language, target language, CEFR select (A1..C2), location, timezone, interests, age.
- `POST /agents` — validates at the trust boundary (CEFR constrained to A1..C2, age numeric, timezone a valid IANA name via `zoneinfo`, required fields), persists the structured persona columns, seeds the persona into `graph:real`, and 303-redirects to `/agents`.
- `POST /agents/{id}/start` — creates a conversation for the current user + agent, 302-redirects to `/c/{id}`.

## Details

- Extended `db.create_agent` with OPTIONAL kwargs for the structured fields (`location`, `timezone`, `interests`, `age`, `native_language`); only given columns are set, so existing 4-arg callers (provisioner + tests) still pass.
- Added `db.list_agents`, `db.get_agent`, and `db.get_account_id_for_user` (unscoped resolver mapping a session's user id to its owning account).
- `require_session` now resolves the account id once and rides it on the session tuple (`session[3]`), so account-scoped routes need no re-lookup.
- Graph seeding reuses the existing `Graph.seed_persona` helper (no parallel graph API); the system prompt is built from the existing `persona.build_persona_prompt`.
- htmx templates are minimal/unstyled, no custom JS.

## Validation

- `uv run python -m unittest discover -s tests`: 117 tests, OK (was 110; +7 in `tests/test_agents.py`).
- `uv run python -m scripts.provision --database /tmp/p118.db --reset`: still works (4-arg `create_agent` path intact).

Test plan covered: login, POST /agents redirect, GET /agents shows the persona, agent row has structured fields set, persona self-quad seeded into `graph:real`, POST start -> 302 + conversation row, plus validation rejections and auth guards.