### PR TITLE
Add chat UI: conversation dashboard and chat view (resolve #120)

### DIFF
--- a/françoise/app.py
+++ b/françoise/app.py
@@ -261,8 +261,38 @@ def App(**kwargs):
                 headers={'Location': '/login'})
 
     @app.get('/', response_class=HTMLResponse)
-    def home(session=Depends(require_session)) -> str:
-        return 'Welcome.'
+    def home(request: Request, session=Depends(require_session)):
+        with open_db(DATABASE_URL, account_id=session[3]) as db:
+            rows = db.list_conversations(session[1])
+        conversations = []
+        for id, agent_name, tz, age in rows:
+            agent = {'timezone': tz, 'age': age}
+            conversations.append({
+                'id': id,
+                'agent_name': agent_name,
+                'presence': '%s %s' % (
+                    presence_label(agent), presence_local_time(agent)),
+            })
+        return TEMPLATES.TemplateResponse(
+            request, 'chat_list.html', {'conversations': conversations})
+
+    @app.get('/c/{id}', response_class=HTMLResponse)
+    def chat(request: Request, id: int, session=Depends(require_session)):
+        with open_db(DATABASE_URL, account_id=session[3]) as db:
+            row = db.get_conversation(id)
+            if row is None:
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+            conversation = db.conversation_to_dict(row)
+            messages = [
+                {'role': r, 'content': c}
+                for r, c in db.get_messages_by_conversation(id)]
+        presence = '%s %s' % (
+            presence_label(conversation), presence_local_time(conversation))
+        return TEMPLATES.TemplateResponse(
+            request, 'chat.html',
+            {'conversation': conversation,
+             'messages': messages,
+             'presence': presence})
 
     @app.get('/agents', response_class=HTMLResponse)
     def list_agents(request: Request, session=Depends(require_session)):

--- a/françoise/db.py
+++ b/françoise/db.py
@@ -329,6 +329,24 @@ class Database:
         """, (id, self.require_account()))
         return res.fetchone()
 
+    def list_conversations(self, user_id: int) -> list:
+        # Account-scoped list for the chat dashboard: one row per conversation
+        # with the persona name plus the timezone/age presence reads.
+        res = self.connection.execute("""
+            SELECT
+                conversation.id,
+                agent.name AS agent_name,
+                agent.timezone AS timezone,
+                agent.age AS age
+            FROM conversations conversation
+            JOIN agents agent
+            ON conversation.agent_id = agent.id
+            WHERE conversation.user_id = ?
+            AND conversation.account_id = ?
+            ORDER BY conversation.id
+        """, (user_id, self.require_account()))
+        return res.fetchall()
+
     def conversation_to_dict(self, conversation: tuple) -> dict[str, str]:
         return dict(zip(('id',
                          'model',

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>{{ conversation.agent_name }}</title>
+    <script src="https://unpkg.com/htmx.org@2"></script>
+    <script src="https://unpkg.com/htmx-ext-sse@2"></script>
+</head>
+<body hx-ext="sse" sse-connect="/stream">
+    <p><a href="/">Back</a></p>
+    <h1>
+        {{ conversation.agent_name }}
+        <span id="presence-{{ conversation.id }}">{{ presence }}</span>
+    </h1>
+    <div id="messages-{{ conversation.id }}">
+        {% for message in messages %}
+        <div>{{ message.content }}</div>
+        {% endfor %}
+    </div>
+    <form hx-post="/c/{{ conversation.id }}/message"
+          hx-target="#messages-{{ conversation.id }}"
+          hx-swap="beforeend"
+          hx-on::after-request="this.reset()">
+        <input type="text" name="message" required>
+        <button type="submit">Send</button>
+    </form>
+</body>
+</html>

--- a/templates/chat_list.html
+++ b/templates/chat_list.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Conversations</title>
+    <script src="https://unpkg.com/htmx.org@2"></script>
+</head>
+<body>
+    <h1>Conversations</h1>
+    <p><a href="/agents/new">Add a friend</a></p>
+    {% if conversations %}
+    <ul>
+        {% for conversation in conversations %}
+        <li>
+            <a href="/c/{{ conversation.id }}">{{ conversation.agent_name }}</a>
+            <span id="presence-{{ conversation.id }}">{{ conversation.presence }}</span>
+            <span id="unread-{{ conversation.id }}">0</span>
+        </li>
+        {% endfor %}
+    </ul>
+    {% else %}
+    <p>No conversations yet.</p>
+    {% endif %}
+</body>
+</html>

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,0 +1,85 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from argon2 import PasswordHasher
+from fastapi.testclient import TestClient
+
+from françoise.app import App
+from françoise.db import open_db
+from françoise.migrate import upgrade_to_head
+
+
+class TestChatUI(unittest.TestCase):
+    def setUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix='.db')
+        os.close(fd)
+
+        upgrade_to_head(self.db_path)
+        password_hash = PasswordHasher().hash('correct horse')
+        with open_db(self.db_path) as db:
+            account = db.create_account('Acme')
+        with open_db(self.db_path, account_id=account[0]) as db:
+            user = db.create_user('Alice', 'alice@example.com', password_hash)
+            agent = db.create_agent('Boku', 'French', 'A1', 'You are {agent_name}.')
+            self.conversation = db.create_conversation(
+                user_id=user[0],
+                agent_id=agent[0],
+                proficiency='A1',
+                model='test-model')
+            db.add_user_message(self.conversation[0], 'Bonjour <b>')
+
+        self.app = App(DATABASE_URL=self.db_path)
+        self.client = TestClient(self.app)
+        self._login()
+
+    def tearDown(self):
+        os.remove(self.db_path)
+
+    def _login(self):
+        response = self.client.post('/login', data={
+            'email': 'alice@example.com',
+            'password': 'correct horse'})
+        self.assertEqual(response.status_code, 200)
+
+    def test_dashboard_lists_conversations(self):
+        response = self.client.get('/')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('href="/c/1"', response.text)
+        self.assertIn('Boku', response.text)
+        self.assertIn('id="presence-1"', response.text)
+        self.assertIn('id="unread-1"', response.text)
+        self.assertIn('/agents/new', response.text)
+
+    def test_chat_view_has_wiring_and_history(self):
+        response = self.client.get('/c/1')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('id="messages-1"', response.text)
+        self.assertIn('id="presence-1"', response.text)
+        self.assertIn('sse-connect="/stream"', response.text)
+        self.assertIn('hx-post="/c/1/message"', response.text)
+        # message history renders, escaped
+        self.assertIn('Bonjour &lt;b&gt;', response.text)
+
+    def test_post_message_returns_echo(self):
+        with patch('françoise.app.stream_inbound', return_value=iter([])):
+            response = self.client.post(
+                '/c/1/message', data={'message': 'Salut'})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('Salut', response.text)
+
+    def test_chat_view_missing_is_404(self):
+        response = self.client.get('/c/999')
+        self.assertEqual(response.status_code, 404)
+
+    def test_routes_require_session(self):
+        anon = TestClient(self.app)
+        for path in ('/', '/c/1'):
+            response = anon.get(path, follow_redirects=False)
+            self.assertEqual(response.status_code, 307)
+            self.assertEqual(response.headers['location'], '/login')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implements #120: server-rendered htmx + Jinja2 chat UI, auth-guarded and account-scoped.

## Changes
- `GET /` — replaces the `'Welcome.'` stub with a conversation-list dashboard. Each row shows the persona name, a link to `/c/{id}`, `id="presence-{id}"`, and `id="unread-{id}"`, plus a link to `/agents/new`.
- `GET /c/{id}` — chat view: renders history in `id="messages-{id}"`, a header `id="presence-{id}"`, the htmx post-form (`hx-post=/c/{id}/message`, `hx-target=#messages-{id}`, `hx-swap=beforeend`, resets on submit), and SSE wiring (`hx-ext="sse" sse-connect="/stream"`) with the htmx + sse-extension CDN scripts. Returns 404 for a conversation outside the account.
- `db.list_conversations(user_id)` — new account-scoped query (id, agent name, timezone, age for presence).
- Templates `templates/chat_list.html` and `templates/chat.html`, rendered via the existing `Jinja2Templates` pattern. Message content is escaped by Jinja2 autoescape.

## Fragment ids
Target ids match exactly what `app.py` emits (`messages-{id}`, `presence-{id}`, `unread-{id}`); no fragment/route code changed.

## Validation
- `uv sync` OK
- `uv run python -m unittest discover -s tests` -> **122 tests, OK**
- `uv run python -m scripts.provision --database /tmp/p120.db --reset` still works

Tests added in `tests/test_chat.py`: login; `GET /` links to `/c/1`; `GET /c/1` contains `id="messages-1"`, `sse-connect="/stream"`, form to `/c/1/message`, escaped history; `POST /c/1/message` -> 200 echo; 404 for missing conversation; both routes require a session.