### PR TITLE
Settings UI: per-conversation CEFR + model, account always-available toggle

### DIFF
--- a/françoise/app.py
+++ b/françoise/app.py
@@ -294,6 +294,60 @@ def App(**kwargs):
              'messages': messages,
              'presence': presence})
 
+    @app.get('/c/{id}/settings', response_class=HTMLResponse)
+    def conversation_settings(
+            request: Request, id: int, session=Depends(require_session)):
+        with open_db(DATABASE_URL, account_id=session[3]) as db:
+            row = db.get_conversation(id)
+            if row is None:
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+            conversation = db.conversation_to_dict(row)
+        return TEMPLATES.TemplateResponse(
+            request, 'conversation_settings.html',
+            {'conversation': conversation, 'cefr_levels': CEFR_LEVELS})
+
+    @app.post('/c/{id}/settings')
+    def update_conversation_settings(
+            request: Request,
+            id: int,
+            proficiency: Annotated[str, Form()],
+            model: Annotated[str, Form()],
+            session=Depends(require_session)):
+        with open_db(DATABASE_URL, account_id=session[3]) as db:
+            row = db.get_conversation(id)
+            if row is None:
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+            if proficiency not in CEFR_LEVELS:
+                conversation = db.conversation_to_dict(row)
+                return TEMPLATES.TemplateResponse(
+                    request, 'conversation_settings.html',
+                    {'conversation': conversation,
+                     'cefr_levels': CEFR_LEVELS,
+                     'error': 'Proficiency must be one of %s.'
+                              % ', '.join(CEFR_LEVELS)},
+                    status_code=status.HTTP_400_BAD_REQUEST)
+            db.update_conversation_settings(id, proficiency, model)
+        return RedirectResponse(
+            '/c/%d' % id, status_code=status.HTTP_303_SEE_OTHER)
+
+    @app.get('/settings', response_class=HTMLResponse)
+    def account_settings(request: Request, session=Depends(require_session)):
+        with open_db(DATABASE_URL, account_id=session[3]) as db:
+            account = db.get_account(session[3])
+        return TEMPLATES.TemplateResponse(
+            request, 'account_settings.html',
+            {'always_available': bool(account[3])})
+
+    @app.post('/settings')
+    def update_account_settings(
+            session=Depends(require_session),
+            always_available: Annotated[Optional[str], Form()] = None):
+        with open_db(DATABASE_URL, account_id=session[3]) as db:
+            db.set_account_always_available(
+                session[3], always_available == 'yes')
+        return RedirectResponse(
+            '/settings', status_code=status.HTTP_303_SEE_OTHER)
+
     @app.get('/agents', response_class=HTMLResponse)
     def list_agents(request: Request, session=Depends(require_session)):
         with open_db(DATABASE_URL, account_id=session[3]) as db:
@@ -401,17 +455,36 @@ def App(**kwargs):
 
         return StreamingResponse(events(), media_type='text/event-stream')
 
-    def get_agent(conversation_id: int) -> dict:
+    def get_agent(conversation_id: int) -> tuple[dict, bool]:
         # The persona fields presence reads (timezone/age) ride on the
         # conversation dict; absent ones fall back to UTC/adult in presence.
+        # Also returns the owning account's always_available toggle.
         with open_db(DATABASE_URL) as resolver:
             account_id = resolver.get_account_id_for_conversation(conversation_id)
         with open_db(DATABASE_URL, account_id=account_id) as db:
-            return db.conversation_to_dict(db.get_conversation(conversation_id))
+            agent = db.conversation_to_dict(db.get_conversation(conversation_id))
+            account = db.get_account(account_id)
+        always_available = bool(account[3]) if account else False
+        return agent, always_available
 
-    async def wait_until_free(agent: dict, poll: float = 60.0) -> None:
+    def is_adult(agent: dict) -> bool:
+        # Presence treats a missing/non-numeric age as an adult (see
+        # presence._schedule), so mirror that here.
+        try:
+            return int(agent.get('age')) >= 18
+        except (TypeError, ValueError):
+            return True
+
+    async def wait_until_free(
+            agent: dict,
+            always_available: bool = False,
+            poll: float = 60.0) -> None:
         # Hold here while the persona is asleep/at school; wake in the next
         # free window. Re-checks presence each poll against the moving clock.
+        # An adult persona on an always-available account skips the wait; a
+        # child persona (age < 18) STILL defers regardless of the toggle.
+        if always_available and is_adult(agent):
+            return
         while not is_free(agent):
             await asyncio.sleep(poll)
 
@@ -419,8 +492,8 @@ def App(**kwargs):
         # Stream the reply through the core and push each chunk to the user's
         # channel so the browser shows the reply as it arrives. Hold the reply
         # until the persona is free (not asleep or at school).
-        agent = get_agent(conversation_id)
-        await wait_until_free(agent)
+        agent, always_available = get_agent(conversation_id)
+        await wait_until_free(agent, always_available)
         channel = get_channel(user_id)
         # Refresh the presence indicator now that the persona is free.
         await channel.put(presence_fragment(conversation_id, agent))

--- a/françoise/db.py
+++ b/françoise/db.py
@@ -8,7 +8,8 @@ tables = [
         [
             ('id', 'INTEGER PRIMARY KEY AUTOINCREMENT'),
             ('name', 'TEXT NOT NULL'),
-            ('created_at', 'TEXT NOT NULL')
+            ('created_at', 'TEXT NOT NULL'),
+            ('always_available', 'INTEGER NOT NULL DEFAULT 0')
         ]
     ),
 
@@ -152,8 +153,15 @@ class Database:
 
     def get_account(self, id: int):
         res = self.connection.execute(
-            "SELECT id, name, created_at FROM accounts WHERE id = ?", (id,))
+            "SELECT id, name, created_at, always_available "
+            "FROM accounts WHERE id = ?", (id,))
         return res.fetchone()
+
+    def set_account_always_available(self, id: int, always_available: bool):
+        with self.connection:
+            self.connection.execute(
+                "UPDATE accounts SET always_available = ? WHERE id = ?",
+                (1 if always_available else 0, id))
 
     def get_account_id_for_conversation(self, conversation_id: int):
         # Unscoped resolver: identifies which tenant owns a conversation so a
@@ -280,6 +288,21 @@ class Database:
                 agent_id=agent_id,
                 proficiency=proficiency,
                 model_config_id=self.upsert_model_config(model))
+
+    def update_conversation_settings(
+            self,
+            conversation_id: int,
+            proficiency: str,
+            model: str):
+        # Reuse the same model-config upsert `create_conversation` uses so a
+        # model string maps to a single shared row, then repoint the FK.
+        model_config_id = self.upsert_model_config(model)
+        with self.connection:
+            self.connection.execute(
+                "UPDATE conversations SET proficiency = ?, model_config_id = ? "
+                "WHERE id = ? AND account_id = ?",
+                (proficiency, model_config_id, conversation_id,
+                 self.require_account()))
 
     def create_message(self, conversation_id: int, role: str, content: str):
         # messages are scoped through their conversation's account

--- a/migrations/versions/b8c9d0e1f2a3_add_always_available.py
+++ b/migrations/versions/b8c9d0e1f2a3_add_always_available.py
@@ -1,0 +1,29 @@
+"""add always_available toggle to accounts
+
+Revision ID: b8c9d0e1f2a3
+Revises: a7b8c9d0e1f2
+Create Date: 2026-08-09 10:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b8c9d0e1f2a3'
+down_revision: Union[str, Sequence[str], None] = 'a7b8c9d0e1f2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.execute(
+        "ALTER TABLE accounts "
+        "ADD COLUMN always_available INTEGER NOT NULL DEFAULT 0;")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.execute("ALTER TABLE accounts DROP COLUMN always_available;")

--- a/templates/account_settings.html
+++ b/templates/account_settings.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Account settings</title>
+</head>
+<body>
+    <p><a href="/">Back</a></p>
+    <h1>Account settings</h1>
+    <form method="post" action="/settings">
+        <label>
+            <input type="checkbox" name="always_available" value="yes"
+                {% if always_available %}checked{% endif %}>
+            Always available (adult personas reply without waiting)
+        </label>
+        <button type="submit">Save</button>
+    </form>
+</body>
+</html>

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -7,7 +7,7 @@
     <script src="https://unpkg.com/htmx-ext-sse@2"></script>
 </head>
 <body hx-ext="sse" sse-connect="/stream">
-    <p><a href="/">Back</a></p>
+    <p><a href="/">Back</a> | <a href="/c/{{ conversation.id }}/settings">Settings</a></p>
     <h1>
         {{ conversation.agent_name }}
         <span id="presence-{{ conversation.id }}">{{ presence }}</span>

--- a/templates/chat_list.html
+++ b/templates/chat_list.html
@@ -7,7 +7,7 @@
 </head>
 <body>
     <h1>Conversations</h1>
-    <p><a href="/agents/new">Add a friend</a></p>
+    <p><a href="/agents/new">Add a friend</a> | <a href="/settings">Settings</a></p>
     {% if conversations %}
     <ul>
         {% for conversation in conversations %}

--- a/templates/conversation_settings.html
+++ b/templates/conversation_settings.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Settings — {{ conversation.agent_name }}</title>
+</head>
+<body>
+    <p><a href="/c/{{ conversation.id }}">Back</a></p>
+    <h1>Settings — {{ conversation.agent_name }}</h1>
+    {% if error %}<p>{{ error }}</p>{% endif %}
+    <form method="post" action="/c/{{ conversation.id }}/settings">
+        <label>Proficiency
+            <select name="proficiency" required>
+                {% for level in cefr_levels %}
+                <option value="{{ level }}"{% if level == conversation.user_proficiency %} selected{% endif %}>{{ level }}</option>
+                {% endfor %}
+            </select>
+        </label>
+        <label>Model
+            <input type="text" name="model" value="{{ conversation.model }}" required>
+        </label>
+        <button type="submit">Save</button>
+    </form>
+</body>
+</html>

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,169 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from argon2 import PasswordHasher
+from fastapi.testclient import TestClient
+
+from françoise.app import App
+from françoise.db import open_db
+from françoise.migrate import upgrade_to_head
+
+
+class _Break(Exception):
+    pass
+
+
+class TestSettings(unittest.TestCase):
+    def setUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix='.db')
+        os.close(fd)
+
+        upgrade_to_head(self.db_path)
+        password_hash = PasswordHasher().hash('correct horse')
+        with open_db(self.db_path) as db:
+            account = db.create_account('Acme')
+        self.account = account
+        with open_db(self.db_path, account_id=account[0]) as db:
+            self.user = db.create_user(
+                'Alice', 'alice@example.com', password_hash)
+            # Adult persona.
+            adult = db.create_agent(
+                'Boku', 'French', 'A1', 'You are {agent_name}.', age=30)
+            self.adult_conversation = db.create_conversation(
+                user_id=self.user[0], agent_id=adult[0],
+                proficiency='A1', model='test-model')
+            # Child persona.
+            child = db.create_agent(
+                'Kiki', 'French', 'A1', 'You are {agent_name}.', age=10)
+            self.child_conversation = db.create_conversation(
+                user_id=self.user[0], agent_id=child[0],
+                proficiency='A1', model='test-model')
+
+        self.app = App(DATABASE_URL=self.db_path)
+        self.client = TestClient(self.app)
+        response = self.client.post('/login', data={
+            'email': 'alice@example.com',
+            'password': 'correct horse'})
+        self.assertEqual(response.status_code, 200)
+
+    def tearDown(self):
+        os.remove(self.db_path)
+
+    # --- per-conversation settings ---
+
+    def test_change_proficiency_persists(self):
+        response = self.client.post(
+            '/c/%d/settings' % self.adult_conversation[0],
+            data={'proficiency': 'B2', 'model': 'test-model'},
+            follow_redirects=False)
+        self.assertEqual(response.status_code, 303)
+        # The persisted level round-trips: reading it back shows B2 selected.
+        with open_db(self.db_path, account_id=self.account[0]) as db:
+            conversation = db.conversation_to_dict(
+                db.get_conversation(self.adult_conversation[0]))
+        self.assertEqual(conversation['user_proficiency'], 'B2')
+        get = self.client.get(
+            '/c/%d/settings' % self.adult_conversation[0])
+        self.assertRegex(get.text, r'value="B2"\s*\n?\s*selected')
+
+    def test_change_model_round_trips(self):
+        self.client.post(
+            '/c/%d/settings' % self.adult_conversation[0],
+            data={'proficiency': 'A1',
+                  'model': 'anthropic/claude-opus-4-8'})
+        with open_db(self.db_path, account_id=self.account[0]) as db:
+            conversation = db.conversation_to_dict(
+                db.get_conversation(self.adult_conversation[0]))
+        self.assertEqual(
+            conversation['model'], 'anthropic/claude-opus-4-8')
+
+    def test_invalid_proficiency_rejected(self):
+        response = self.client.post(
+            '/c/%d/settings' % self.adult_conversation[0],
+            data={'proficiency': 'Z9', 'model': 'test-model'})
+        self.assertEqual(response.status_code, 400)
+        with open_db(self.db_path, account_id=self.account[0]) as db:
+            conversation = db.conversation_to_dict(
+                db.get_conversation(self.adult_conversation[0]))
+        self.assertEqual(conversation['user_proficiency'], 'A1')
+
+    def test_settings_missing_conversation_is_404(self):
+        response = self.client.get('/c/999/settings')
+        self.assertEqual(response.status_code, 404)
+
+    # --- account settings ---
+
+    def test_toggle_always_available_persists(self):
+        response = self.client.post(
+            '/settings', data={'always_available': 'yes'},
+            follow_redirects=False)
+        self.assertEqual(response.status_code, 303)
+        with open_db(self.db_path, account_id=self.account[0]) as db:
+            account = db.get_account(self.account[0])
+        self.assertEqual(account[3], 1)
+        get = self.client.get('/settings')
+        self.assertIn('checked', get.text)
+
+    def test_toggle_off_persists(self):
+        with open_db(self.db_path, account_id=self.account[0]) as db:
+            db.set_account_always_available(self.account[0], True)
+        # Unchecked box sends no field.
+        self.client.post('/settings', data={})
+        with open_db(self.db_path, account_id=self.account[0]) as db:
+            account = db.get_account(self.account[0])
+        self.assertEqual(account[3], 0)
+
+    # --- presence override in reply_and_push ---
+
+    def _post(self, conversation_id, sleep):
+        with patch('françoise.app.asyncio.sleep', side_effect=sleep), \
+                patch('françoise.app.stream_inbound',
+                      return_value=iter(['Bonjour !'])):
+            try:
+                self.client.post(
+                    '/c/%d/message' % conversation_id,
+                    data={'message': 'Hello'})
+            except _Break:
+                pass
+
+    def test_always_available_adult_replies_without_waiting(self):
+        # always-available ON: an adult persona replies immediately even while
+        # asleep. asyncio.sleep raising proves the wait loop is never entered.
+        self.client.post('/settings', data={'always_available': 'yes'})
+        channel = self.app.state.get_channel(self.user[0])
+
+        def sleep(*a, **k):
+            raise _Break()
+
+        # Asleep hours in UTC for an adult; without the override this defers.
+        with patch('françoise.app.is_free', return_value=False):
+            self._post(self.adult_conversation[0], sleep)
+
+        fragments = []
+        while not channel.empty():
+            fragments.append(channel.get_nowait())
+        self.assertTrue(any('Bonjour !' in f for f in fragments))
+
+    def test_always_available_child_still_defers(self):
+        # always-available ON must NEVER bypass a child persona's sleep: the
+        # wait loop IS entered, so asyncio.sleep raising breaks out with no
+        # reply pushed.
+        self.client.post('/settings', data={'always_available': 'yes'})
+        channel = self.app.state.get_channel(self.user[0])
+
+        def sleep(*a, **k):
+            raise _Break()
+
+        with patch('françoise.app.is_free', return_value=False):
+            self._post(self.child_conversation[0], sleep)
+
+        fragments = []
+        while not channel.empty():
+            fragments.append(channel.get_nowait())
+        self.assertFalse(any('Bonjour !' in f for f in fragments))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #122.

## What
Third of the Web UI phase (Persona -> Chat -> **Settings**). Adds the configurable knobs behind \`require_session\`, account-scoped, server-rendered htmx + Jinja2, no custom JS.

### Per-conversation settings (\`GET/POST /c/{id}/settings\`)
- Change CEFR \`proficiency\` (select A1..C2, validated; invalid -> 400 re-render).
- Change the model string; reuses the existing \`model_configs\` upsert and repoints \`conversations.model_config_id\` via new \`db.update_conversation_settings\`.
- Redirects to \`/c/{id}\` on success.

### Account settings (\`GET/POST /settings\`)
- Always-available toggle persisted on the new \`accounts.always_available\` column (Alembic migration \`b8c9d0e1f2a3\`, default 0).
- Honored in \`reply_and_push\`/\`wait_until_free\`: if the account is always-available **and** the persona is an adult (\`age >= 18\`), the reply skips the wait. A **child persona (age < 18) STILL defers** regardless of the toggle — the toggle can never bypass a child's sleep.

### Links
- Chat view links to \`/c/{id}/settings\`; dashboard links to \`/settings\`.

## Validation
- \`uv run python -m unittest discover -s tests\`: **130 tests OK** (was 122+).
- New \`tests/test_settings.py\` covers CEFR persist/round-trip, invalid rejection, model round-trip, toggle persist on/off, and the presence override. Critically it asserts **both**: with always-available ON an adult replies without waiting, and a child still defers (\`test_always_available_child_still_defers\`).
- \`scripts.provision --reset\` runs; the migration applies cleanly on a fresh DB (\`always_available INTEGER NOT NULL DEFAULT 0\`).