### PR TITLE
Implement design system: base layout, tokens, fonts, paper texture (#125)

### DIFF
--- a/françoise/app.py
+++ b/françoise/app.py
@@ -22,6 +22,7 @@ from fastapi import (
     status,
 )
 from fastapi.responses import HTMLResponse, RedirectResponse, StreamingResponse
+from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from evals.harness import CEFR_LEVELS
@@ -34,18 +35,6 @@ from .persona import build_persona_prompt
 from .presence import is_free, presence_label, presence_local_time
 
 TEMPLATES = Jinja2Templates(directory='templates')
-
-LOGIN_FORM = """<!DOCTYPE html>
-<html lang="en">
-<body>
-    <form method="post" action="/login">
-        <input type="email" name="email" required>
-        <input type="password" name="password" required>
-        <button type="submit">Log in</button>
-    </form>
-</body>
-</html>
-"""
 
 SIGNUP_FORM = """<!DOCTYPE html>
 <html lang="en">
@@ -95,6 +84,8 @@ def get_config(
 def App(**kwargs):
 
     app = FastAPI()
+
+    app.mount('/static', StaticFiles(directory='static'), name='static')
 
     DATABASE_URL = get_config(kwargs, 'DATABASE_URL', 'data.db')
     LLM_API_CHAT_URL = get_config(kwargs, 'LLM_API_CHAT_URL', 'http://localhost:11434/api/chat')
@@ -193,8 +184,8 @@ def App(**kwargs):
             response.status_code = status.HTTP_401_UNAUTHORIZED
 
     @app.get('/login', response_class=HTMLResponse)
-    def login_form() -> str:
-        return LOGIN_FORM
+    def login_form(request: Request):
+        return TEMPLATES.TemplateResponse(request, 'login.html')
 
     @app.post('/login', response_class=HTMLResponse)
     def login(

--- a/static/app.css
+++ b/static/app.css
@@ -1,0 +1,205 @@
+/* françoise design system — tokens + core components (design.md v1.0).
+   Adapted from the rendered specimen; tokens reconciled to design.md
+   (cool oyster paper, paperShade, Fraunces/Work Sans/Courier Prime). */
+
+:root {
+  /* colors */
+  --paper: #EDEBE4;       /* cool oyster — the ground everywhere; never white */
+  --paperShade: #E3DFD4;  /* recessed/raised paper for cards and wells */
+  --ink: #23201C;
+  --inkMuted: #6B6355;
+  --rule: #C8B896;
+  --teal: #0E7C7B;
+  --coral: #E2603F;
+  --ochre: #E0A63C;
+  --navy: #234A6B;
+  --olive: #5C7A3D;
+  --vermilion: #C8452E;
+  --focus: var(--ochre);
+  --success: var(--olive);
+  --error: var(--vermilion);
+
+  /* rounded */
+  --rounded-none: 0;
+  --rounded-sm: 2px;
+  --rounded-md: 4px;
+  --rounded-pill: 999px;
+
+  /* spacing (8px-derived) */
+  --space-xs: 4px;
+  --space-sm: 8px;
+  --space-md: 16px;
+  --space-lg: 24px;
+  --space-xl: 40px;
+  --space-xxl: 64px;
+  --space-xxxl: 96px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background-color: var(--paper);
+  color: var(--ink);
+  font-family: "Work Sans", sans-serif;
+  font-size: 16px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* Paper grain — inline SVG feTurbulence multiplied over paper, quiet. */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 9999;
+  opacity: .5;
+  mix-blend-mode: multiply;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.06'/%3E%3C/svg%3E");
+}
+
+.wrap {
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: var(--space-xxl) var(--space-xl) var(--space-xxxl);
+}
+
+/* Masthead / nameplate — Fraunces at masthead scale over a rule. */
+.masthead {
+  font-family: "Fraunces", serif;
+  font-weight: 600;
+  font-size: 64px;
+  line-height: 1;
+  letter-spacing: -.02em;
+  margin: 0;
+  color: var(--ink);
+}
+.masthead a { color: inherit; text-decoration: none; }
+
+.kicker {
+  font-family: "Courier Prime", monospace;
+  font-weight: 700;
+  font-size: 12px;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--vermilion);
+}
+
+/* Rules / dividers. */
+.rule { height: 2px; background: var(--ink); border: 0; margin: var(--space-md) 0 var(--space-sm); }
+.rule-thin { height: 1px; background: var(--rule); border: 0; }
+
+/* Type roles (design.md). */
+.t-display  { font-family: "Fraunces", serif; font-weight: 600; font-size: 40px; line-height: 1.05; letter-spacing: -.01em; }
+.t-heading  { font-family: "Fraunces", serif; font-weight: 600; font-size: 24px; line-height: 1.15; letter-spacing: 0; }
+.t-body     { font-family: "Work Sans", sans-serif; font-size: 16px; line-height: 1.6; max-width: 66ch; }
+.t-caption  { font-family: "Work Sans", sans-serif; font-weight: 500; font-size: 13px; letter-spacing: .02em; line-height: 1.4; }
+.t-postmark { font-family: "Courier Prime", monospace; font-weight: 700; font-size: 12px; line-height: 1.2; letter-spacing: .08em; text-transform: uppercase; }
+
+/* Buttons — square-ish, ink fill, tracked caption; hard block-shadow on hover. */
+.button {
+  font-family: "Work Sans", sans-serif;
+  font-weight: 500;
+  font-size: 13px;
+  letter-spacing: .02em;
+  padding: 12px 20px;
+  border: 0;
+  border-radius: var(--rounded-sm);
+  cursor: pointer;
+  background: var(--ink);
+  color: var(--paper);
+  text-decoration: none;
+  display: inline-block;
+  box-shadow: none;
+  transition: box-shadow .1s, transform .1s;
+}
+.button:hover { box-shadow: 4px 4px 0 var(--teal); }
+.buttonAccent { background: var(--coral); }
+.buttonAccent:hover { box-shadow: 4px 4px 0 var(--ink); }
+.buttonSecondary { background: transparent; color: var(--ink); border: 1px solid var(--ink); }
+.buttonSecondary:hover { box-shadow: 4px 4px 0 var(--ink); }
+
+/* Inputs / selects — cream field, hairline rule, deboss, ochre focus. */
+label {
+  display: block;
+  font-family: "Work Sans", sans-serif;
+  font-weight: 500;
+  font-size: 13px;
+  letter-spacing: .02em;
+  margin-bottom: 6px;
+}
+.input, input:not([type=checkbox]):not([type=radio]), select, textarea {
+  width: 100%;
+  font-family: "Work Sans", sans-serif;
+  font-size: 15px;
+  padding: 10px 12px;
+  background: var(--paper);
+  color: var(--ink);
+  border: 1px solid var(--rule);
+  border-radius: var(--rounded-sm);
+  box-shadow: inset 1px 1px 0 rgba(0, 0, 0, .08), inset -1px -1px 0 rgba(255, 255, 255, .5);
+}
+.input:focus, input:focus, select:focus, textarea:focus {
+  outline: 0;
+  border-color: var(--ochre);
+}
+
+.field { display: block; margin-top: var(--space-md); max-width: 360px; }
+
+/* Postcard — the workhorse card: paperShade ground, hairline frame. */
+.postcard {
+  position: relative;
+  background: var(--paperShade);
+  border: 1px solid var(--rule);
+  border-radius: var(--rounded-none);
+  padding: var(--space-lg);
+}
+.postcard::before {
+  content: "";
+  position: absolute;
+  inset: 6px;
+  border: 1px dashed var(--rule);
+  pointer-events: none;
+}
+
+/* Stamp / badge — Courier Prime, dashed vermilion edge. */
+.stamp {
+  font-family: "Courier Prime", monospace;
+  font-weight: 700;
+  font-size: 11px;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--vermilion);
+  border: 1px dashed var(--vermilion);
+  padding: 4px 8px;
+  text-align: center;
+}
+.badge {
+  font-family: "Courier Prime", monospace;
+  font-weight: 700;
+  font-size: 11px;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  padding: 5px 10px;
+  border: 1px solid var(--ink);
+}
+.badge.level { background: var(--teal); color: var(--paper); border-color: var(--teal); }
+.badge.presence { color: var(--vermilion); border: 1px dashed var(--vermilion); }
+.badge.unread { background: var(--coral); color: var(--paper); border-color: var(--coral); border-radius: var(--rounded-pill); }
+
+/* Depth — print, not Material. */
+.deboss { border: 1px solid var(--rule); box-shadow: inset 2px 2px 0 rgba(0, 0, 0, .08), inset -1px -1px 0 rgba(255, 255, 255, .6); }
+.block-shadow { border: 1px solid var(--ink); box-shadow: 4px 4px 0 var(--navy); }
+
+/* Par avion border — red/blue dashed airmail frame for correspondence cards. */
+.avion {
+  padding: 20px 24px;
+  background: var(--paper);
+  border: 2px solid transparent;
+  background-image:
+    linear-gradient(var(--paper), var(--paper)),
+    repeating-linear-gradient(45deg, var(--coral) 0 10px, var(--paper) 10px 20px, var(--navy) 20px 30px, var(--paper) 30px 40px);
+  background-origin: border-box;
+  background-clip: padding-box, border-box;
+}

--- a/static/app.css
+++ b/static/app.css
@@ -192,6 +192,28 @@ label {
 .deboss { border: 1px solid var(--rule); box-shadow: inset 2px 2px 0 rgba(0, 0, 0, .08), inset -1px -1px 0 rgba(255, 255, 255, .6); }
 .block-shadow { border: 1px solid var(--ink); box-shadow: 4px 4px 0 var(--navy); }
 
+/* Auth — a centered, constrained card for login / signup. App surfaces stay wide. */
+.auth {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-xl);
+}
+.auth-card {
+  width: 100%;
+  max-width: 400px;
+  position: relative;
+  background: var(--paperShade);
+  border: 1px solid var(--rule);
+  border-top: 3px solid var(--coral);
+  padding: var(--space-xl);
+}
+.auth-head { text-align: center; margin-bottom: var(--space-sm); }
+.auth-card .masthead { font-size: 40px; }
+.auth-card .field { max-width: none; }
+.auth-card .button { width: 100%; text-align: center; margin-top: var(--space-sm); }
+
 /* Par avion border — red/blue dashed airmail frame for correspondence cards. */
 .avion {
   padding: 20px 24px;

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}françoise{% endblock %}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Work+Sans:wght@400;500;600&family=Courier+Prime:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/static/app.css">
+    <script src="https://unpkg.com/htmx.org@2"></script>
+    {% block head %}{% endblock %}
+</head>
+<body>
+    <div class="wrap">
+        <header>
+            <h1 class="masthead"><a href="/">françoise</a></h1>
+            <hr class="rule">
+            {% block nav %}{% endblock %}
+        </header>
+        <main>
+            {% block content %}{% endblock %}
+        </main>
+    </div>
+</body>
+</html>

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,6 +12,7 @@
     {% block head %}{% endblock %}
 </head>
 <body>
+    {% block shell %}
     <div class="wrap">
         <header>
             <h1 class="masthead"><a href="/">françoise</a></h1>
@@ -22,5 +23,6 @@
             {% block content %}{% endblock %}
         </main>
     </div>
+    {% endblock %}
 </body>
 </html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{% block title %}Log in · françoise{% endblock %}
+{% block content %}
+<form method="post" action="/login">
+    <div class="field">
+        <label for="email">Email</label>
+        <input type="email" id="email" name="email" required>
+    </div>
+    <div class="field">
+        <label for="password">Password</label>
+        <input type="password" id="password" name="password" required>
+    </div>
+    <div class="field">
+        <button type="submit" class="button buttonAccent">Log in</button>
+    </div>
+</form>
+{% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,17 +1,26 @@
 {% extends "base.html" %}
 {% block title %}Log in · françoise{% endblock %}
-{% block content %}
-<form method="post" action="/login">
-    <div class="field">
-        <label for="email">Email</label>
-        <input type="email" id="email" name="email" required>
+{% block shell %}
+<div class="auth">
+    <div class="auth-card">
+        <div class="auth-head">
+            <div class="kicker">Welcome back</div>
+            <h1 class="masthead"><a href="/">françoise</a></h1>
+        </div>
+        <hr class="rule">
+        <form method="post" action="/login">
+            <div class="field">
+                <label for="email">Email</label>
+                <input type="email" id="email" name="email" required>
+            </div>
+            <div class="field">
+                <label for="password">Password</label>
+                <input type="password" id="password" name="password" required>
+            </div>
+            <div class="field">
+                <button type="submit" class="button buttonAccent">Log in</button>
+            </div>
+        </form>
     </div>
-    <div class="field">
-        <label for="password">Password</label>
-        <input type="password" id="password" name="password" required>
-    </div>
-    <div class="field">
-        <button type="submit" class="button buttonAccent">Log in</button>
-    </div>
-</form>
+</div>
 {% endblock %}

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -34,6 +34,18 @@ class TestLoginRoutes(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn('<form', response.text)
 
+    def test_login_extends_base_shell(self):
+        # The template extends base.html: masthead nameplate + served CSS.
+        response = self.client.get('/login')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('class="masthead"', response.text)
+        self.assertIn('/static/app.css', response.text)
+
+    def test_static_css_serves(self):
+        response = self.client.get('/static/app.css')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('--paper', response.text)
+
     def test_correct_password_creates_session(self):
         response = self.client.post('/login', data={
             'email': 'alice@example.com',


### PR DESCRIPTION
Resolves #125.

Turns `design.md` into the shared front-end foundation every page inherits.

## What's in it
- **`templates/base.html`** — shared layout: loads Fraunces / Work Sans / Courier Prime (Google Fonts), links `/static/app.css`, applies the cool-oyster paper ground + inline-SVG `feTurbulence` grain, and renders the "françoise" masthead nameplate over a rule with `{% block content %}` / `{% block nav %}` / `{% block head %}` for pages to fill. htmx is loaded here so pages inherit it.
- **`static/app.css`** — `design.md` tokens as CSS custom properties (colors, type roles, `rounded`, spacing) plus component classes: `button` / `buttonAccent` / `buttonSecondary`, `input`/`select` (debossed), `postcard`, `stamp`/`badge`, `masthead`, `rule`/`rule-thin`, `deboss`, `block-shadow`, and the par-avion frame. Plain CSS, no build step. Adapted from the rendered specimen at `/tmp/design-preview.html` with tokens reconciled to `design.md` (cool oyster `#EDEBE4`, `paperShade #E3DFD4`, design.md type sizes/weights).
- **`app.py`** — mounts `StaticFiles` at `/static`; `/login` now renders `templates/login.html` (extends `base.html`) instead of the inline `LOGIN_FORM` string. `POST /login` behavior is unchanged.
- **`templates/login.html`** — on-brand smoke test proving the system renders end to end.

## Validation
- `uv sync` clean.
- `uv run python -m unittest discover -s tests` → **132 tests, OK**. Added tests: `/static/app.css` serves 200 and `/login` renders the base shell (masthead + stylesheet link).
- `uv run python -m scripts.provision --database /tmp/p125.db --reset` still works.
- htmx behavior intact; no custom JS.