### PR TITLE
Public magazine-cover landing at `/`; move dashboard to `/app` (#126)

### DIFF
--- a/françoise/app.py
+++ b/françoise/app.py
@@ -252,6 +252,19 @@ def App(**kwargs):
                 headers={'Location': '/login'})
 
     @app.get('/', response_class=HTMLResponse)
+    def landing(request: Request,
+                session: Annotated[Optional[str], Cookie()] = None):
+        # Public magazine-cover landing. No auth: anonymous visitors see the
+        # cover series; a logged-in visitor gets a link into the app instead
+        # of the sign-up CTA.
+        logged_in = False
+        if session is not None:
+            with open_db(DATABASE_URL) as db:
+                logged_in = db.get_session(session) is not None
+        return TEMPLATES.TemplateResponse(
+            request, 'landing.html', {'logged_in': logged_in})
+
+    @app.get('/app', response_class=HTMLResponse)
     def home(request: Request, session=Depends(require_session)):
         with open_db(DATABASE_URL, account_id=session[3]) as db:
             rows = db.list_conversations(session[1])

--- a/static/app.css
+++ b/static/app.css
@@ -214,6 +214,90 @@ label {
 .auth-card .field { max-width: none; }
 .auth-card .button { width: 100%; text-align: center; margin-top: var(--space-sm); }
 
+/* Landing — a sequence of full-bleed magazine covers. One accent per cover;
+   the françoise nameplate recurs; Fraunces headline is the picture; Courier
+   cover-lines sit in a corner; a stamp/postmark motif marks each. */
+.covers { width: 100%; }
+.cover {
+  position: relative;
+  min-height: 100vh;
+  padding: var(--space-xl) clamp(var(--space-lg), 6vw, var(--space-xxxl));
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  gap: var(--space-lg);
+  border-bottom: 2px solid var(--ink);
+  overflow: hidden;
+}
+/* Accent grounds — color arrives in confident blocks (design.md). */
+.cover--teal  { background: var(--teal);  color: var(--paper); }
+.cover--coral { background: var(--coral); color: var(--paper); }
+.cover--ochre { background: var(--ochre); color: var(--ink); }
+.cover--navy  { background: var(--navy);  color: var(--paper); }
+
+.cover__plate {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--space-md);
+  border-bottom: 2px solid currentColor;
+  padding-bottom: var(--space-sm);
+}
+.cover__nameplate {
+  font-family: "Fraunces", serif;
+  font-weight: 600;
+  font-size: clamp(40px, 8vw, 72px);
+  line-height: 1;
+  letter-spacing: -.02em;
+  color: inherit;
+}
+.cover__issue { color: inherit; opacity: .85; }
+
+.cover__headline {
+  align-self: center;
+  margin: 0;
+  font-family: "Fraunces", serif;
+  font-weight: 600;
+  font-size: clamp(44px, 11vw, 128px);
+  line-height: 1.0;
+  letter-spacing: -.02em;
+  color: inherit;
+}
+
+/* Cover-lines tucked in a corner, typewriter face. */
+.cover__lines {
+  align-self: end;
+  justify-self: start;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  color: inherit;
+  opacity: .9;
+}
+.cover__lines li { padding: 2px 0; }
+.cover__lines li::before { content: "— "; }
+
+/* Stamp motif pinned to the top corner of each cover. */
+.cover__stamp {
+  position: absolute;
+  top: var(--space-xl);
+  right: clamp(var(--space-lg), 6vw, var(--space-xxxl));
+  color: var(--paper);
+  border-color: var(--paper);
+  transform: rotate(4deg);
+}
+.cover--ochre .cover__stamp { color: var(--ink); border-color: var(--ink); }
+
+.cover__cta {
+  align-self: end;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-md);
+}
+/* Secondary CTA reads on the navy ground. */
+.cover--navy .buttonSecondary { color: var(--paper); border-color: var(--paper); }
+.cover--navy .buttonSecondary:hover { box-shadow: 4px 4px 0 var(--paper); }
+
 /* Par avion border — red/blue dashed airmail frame for correspondence cards. */
 .avion {
   padding: 20px 24px;

--- a/static/landing.css
+++ b/static/landing.css
@@ -1,0 +1,217 @@
+/* Landing — a magazine desk collage. Loads after app.css (tokens available).
+   Breaks the grid: rotated, overlapping items on the oyster "desk", torn and
+   airmail transitions, SVG illustration instead of stock photography. */
+
+.lp { overflow-x: clip; }
+.lp section { position: relative; }
+
+/* Shared print-card lift: hard offset shadow + hairline, like paper on a desk. */
+.card-print {
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  box-shadow: 5px 6px 0 rgba(35, 32, 28, .18);
+}
+
+/* Handwritten margin notes. */
+.note {
+  font-family: "Caveat", cursive;
+  font-weight: 600;
+  font-size: 30px;
+  color: var(--vermilion);
+  line-height: .95;
+}
+
+/* Circular postmark / cancellation. */
+.postmark {
+  width: 92px; height: 92px; border-radius: 50%;
+  border: 2px dashed var(--vermilion); color: var(--vermilion);
+  display: grid; place-content: center; text-align: center;
+  font-family: "Courier Prime", monospace; font-weight: 700;
+  font-size: 10px; letter-spacing: .1em; text-transform: uppercase;
+  transform: rotate(-11deg);
+}
+
+/* Boarding-pass ticket with a perforation notch. */
+.ticket {
+  display: inline-flex; align-items: stretch; min-width: 210px;
+  background: var(--paper); border: 1px solid var(--ink);
+  box-shadow: 4px 4px 0 var(--teal); font-family: "Courier Prime", monospace;
+}
+.ticket__stub {
+  background: var(--teal); color: var(--paper); padding: 10px 12px;
+  writing-mode: vertical-rl; text-orientation: mixed;
+  font-weight: 700; font-size: 11px; letter-spacing: .18em; text-transform: uppercase;
+}
+.ticket__body { padding: 10px 14px; font-size: 11px; line-height: 1.5; color: var(--ink); }
+.ticket__body b { font-size: 15px; letter-spacing: .04em; }
+
+/* ---- HERO: a color-forward desk ---- */
+.lp-hero { padding: var(--space-xl) var(--space-lg); overflow: hidden; }
+.desk {
+  position: relative; max-width: 1080px; margin: 0 auto; min-height: 640px;
+  display: flex; align-items: center;
+}
+.desk__item { position: absolute; }
+
+/* Color mass — mid-century roundels bleeding behind the cover. */
+.roundel { border-radius: 50%; }
+.i-roundel { top: -80px; right: -70px; z-index: 0; }
+.i-roundel .roundel { width: 360px; height: 360px; background: var(--coral); }
+.i-roundel-2 { bottom: -70px; left: -60px; z-index: 0; }
+.i-roundel-2 .roundel { width: 210px; height: 210px; background: var(--ochre); }
+
+/* The flagship cover — a bold teal field, masthead reversed in cream. */
+.hero-cover {
+  position: relative; z-index: 4; width: min(560px, 92%);
+  margin: 0 auto; padding: 40px 44px;
+  background: var(--teal); color: var(--paper);
+  border: 1px solid var(--ink); box-shadow: 12px 13px 0 rgba(35, 32, 28, .28);
+  transform: rotate(-1.5deg);
+}
+.hero-cover .cover-issue {
+  display: flex; justify-content: space-between;
+  font-family: "Courier Prime", monospace; font-size: 12px; letter-spacing: .14em;
+  text-transform: uppercase; color: var(--paper); opacity: .85;
+}
+.hero-cover .cover-name {
+  font-family: "Fraunces", serif; font-weight: 600; font-size: 92px; line-height: .84;
+  letter-spacing: -.035em; margin: 10px 0 16px; color: var(--paper);
+}
+.hero-cover .cover-head {
+  font-family: "Fraunces", serif; font-weight: 500; font-size: 28px; line-height: 1.12;
+  max-width: 22ch; margin: 0; color: var(--paper);
+}
+.hero-cover .cover-lines {
+  list-style: none; margin: 22px 0 0; padding: 0;
+  font-family: "Courier Prime", monospace; font-size: 11px; letter-spacing: .08em;
+  text-transform: uppercase; color: var(--paper);
+}
+.hero-cover .cover-lines li { padding: 6px 0; border-top: 1px solid rgba(243, 238, 227, .28); }
+
+/* Scattered desk furniture — paper items straddling the color field. */
+.i-photo { top: -34px; left: -48px; z-index: 5; transform: rotate(-7deg); }
+.i-postmark { top: 42%; right: -34px; z-index: 6; }
+.i-ticket { bottom: -24px; right: 26px; z-index: 6; transform: rotate(4deg); }
+.i-note-1 { bottom: 20px; left: -42px; z-index: 6; transform: rotate(-6deg); }
+.i-plane { top: 4px; right: 54px; z-index: 5; transform: rotate(-4deg); }
+.i-sun { bottom: -34px; left: 42%; z-index: 1; opacity: .95; }
+
+/* Background sky — flight paths + distant planes + halftone, behind the cover. */
+.desk__bg { position: absolute; inset: -40px -20px; z-index: 0; pointer-events: none; }
+.desk__bg .routes { width: 100%; height: 100%; display: block; }
+.i-plane-2 { top: 46px; left: 54px; z-index: 1; transform: rotate(9deg); opacity: .7; }
+.i-plane-3 { top: 168px; right: 120px; z-index: 1; transform: rotate(-15deg); opacity: .5; }
+.i-plane-4 { bottom: 30px; left: 34%; z-index: 1; transform: rotate(3deg); opacity: .45; }
+.i-dots { top: 220px; left: 8px; z-index: 1; opacity: .6; }
+.i-star { top: 24px; left: 46%; z-index: 1; opacity: .8; }
+
+/* Extra desk props — more photos + a second boarding pass. */
+.photo--sm { width: 152px; }
+.i-photo-2 { bottom: 26px; right: -52px; z-index: 5; transform: rotate(6deg); }
+.i-photo-3 { bottom: -40px; left: 30%; z-index: 5; transform: rotate(-5deg); }
+.i-ticket-2 { top: 38%; left: -72px; z-index: 6; transform: rotate(-6deg); }
+.ticket--coral .ticket__stub { background: var(--coral); }
+.ticket--coral { box-shadow: 4px 4px 0 var(--ochre); }
+
+/* A "photo print" = SVG illustration in a white border, Polaroid-ish. */
+.photo {
+  padding: 8px 8px 26px; background: #FBF8F1; border: 1px solid var(--rule);
+  box-shadow: 5px 6px 0 rgba(35, 32, 28, .2); width: 200px;
+}
+.photo svg { display: block; width: 100%; height: auto; }
+.photo__cap {
+  font-family: "Caveat", cursive; font-weight: 600; font-size: 20px;
+  color: var(--ink); text-align: center; margin-top: 6px;
+}
+
+/* ---- Transitions ---- */
+.ribbon-avion {
+  color: var(--paper); font-family: "Courier Prime", monospace; font-weight: 700;
+  font-size: 12px; letter-spacing: .35em; text-transform: uppercase;
+  padding: 10px 0; text-align: center; overflow: hidden; white-space: nowrap;
+  background: repeating-linear-gradient(45deg,
+    var(--coral) 0 14px, var(--navy) 14px 28px);
+  transform: rotate(-1deg); margin: 8px 0;
+}
+.divider-torn { display: block; width: 100%; height: 46px; }
+.stamps-strip {
+  display: flex; gap: 14px; justify-content: center; flex-wrap: wrap;
+  padding: 28px var(--space-lg);
+}
+.stamp-il {
+  width: 92px; padding: 6px; background: var(--paper);
+  border: 1px dashed var(--ink); text-align: center;
+  transform: rotate(var(--r, -3deg));
+}
+.stamp-il svg { display: block; width: 100%; height: 62px; }
+.stamp-il span {
+  font-family: "Courier Prime", monospace; font-size: 8px; font-weight: 700;
+  letter-spacing: .08em; text-transform: uppercase; color: var(--ink);
+}
+
+/* ---- Section headers (editorial deck) ---- */
+.lp-deck { text-align: center; padding: var(--space-xl) var(--space-lg) 0; }
+.lp-deck .kicker { color: var(--vermilion); }
+.lp-deck h2 {
+  font-family: "Fraunces", serif; font-weight: 600; font-size: 40px;
+  letter-spacing: -.01em; margin: 6px 0 0;
+}
+
+/* ---- Scattered postcards (dispatches / friends) ---- */
+.scatter {
+  position: relative; max-width: 1000px; margin: 0 auto;
+  display: flex; flex-wrap: wrap; justify-content: center;
+  gap: 8px; padding: var(--space-xl) var(--space-lg) var(--space-xxl);
+}
+.pc {
+  position: relative; width: 300px; padding: 20px; background: var(--paperShade);
+  border: 1px solid var(--rule); box-shadow: 5px 6px 0 rgba(35, 32, 28, .16);
+}
+.pc:nth-child(1) { transform: rotate(-4deg); }
+.pc:nth-child(2) { transform: rotate(2.5deg); margin-top: 34px; }
+.pc:nth-child(3) { transform: rotate(-2deg); margin-top: 12px; }
+.pc:nth-child(4) { transform: rotate(3.5deg); }
+.pc__stamp {
+  position: absolute; top: 12px; right: 12px; width: 54px; padding: 4px;
+  background: var(--paper); border: 1px dashed var(--vermilion); text-align: center;
+}
+.pc__stamp svg { display: block; width: 100%; height: 34px; }
+.pc__place {
+  font-family: "Courier Prime", monospace; font-size: 11px; letter-spacing: .1em;
+  text-transform: uppercase; color: var(--vermilion);
+}
+.pc__name {
+  font-family: "Fraunces", serif; font-weight: 600; font-size: 26px; margin: 2px 0 8px;
+}
+.pc__note { font-size: 14px; color: var(--ink); margin: 0; max-width: 30ch; }
+.pc__level {
+  margin-top: 14px; display: inline-block;
+  font-family: "Courier Prime", monospace; font-size: 10px; font-weight: 700;
+  letter-spacing: .08em; text-transform: uppercase;
+  background: var(--teal); color: var(--paper); padding: 4px 8px;
+}
+
+/* ---- Final CTA — a navy field to bookend the color ---- */
+.lp-cta {
+  text-align: center; padding: var(--space-xxl) var(--space-lg) var(--space-xxxl);
+  background: var(--navy); color: var(--paper);
+}
+.lp-cta .cover-issue { color: var(--paper); opacity: .85; }
+.lp-cta .cover-name {
+  font-family: "Fraunces", serif; font-weight: 600; font-size: 72px; line-height: .9;
+  letter-spacing: -.035em; margin: 8px 0 6px; color: var(--paper);
+}
+.lp-cta h2 {
+  font-family: "Fraunces", serif; font-weight: 500; font-size: 30px; margin: 0 0 24px;
+  color: var(--paper);
+}
+.lp-cta .actions { display: flex; gap: 14px; justify-content: center; flex-wrap: wrap; }
+.lp-cta .buttonSecondary { color: var(--paper); border-color: var(--paper); }
+.lp-cta .buttonSecondary:hover { box-shadow: 4px 4px 0 var(--teal); }
+
+@media (max-width: 720px) {
+  .desk { min-height: 0; }
+  .desk__item { position: static; transform: none !important; margin: 16px auto; display: block; width: fit-content; }
+  .hero-cover { transform: none; margin-top: 0; }
+  .i-sun { display: none; }
+}

--- a/templates/account_settings.html
+++ b/templates/account_settings.html
@@ -5,7 +5,7 @@
     <title>Account settings</title>
 </head>
 <body>
-    <p><a href="/">Back</a></p>
+    <p><a href="/app">Back</a></p>
     <h1>Account settings</h1>
     <form method="post" action="/settings">
         <label>

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -7,7 +7,7 @@
     <script src="https://unpkg.com/htmx-ext-sse@2"></script>
 </head>
 <body hx-ext="sse" sse-connect="/stream">
-    <p><a href="/">Back</a> | <a href="/c/{{ conversation.id }}/settings">Settings</a></p>
+    <p><a href="/app">Back</a> | <a href="/c/{{ conversation.id }}/settings">Settings</a></p>
     <h1>
         {{ conversation.agent_name }}
         <span id="presence-{{ conversation.id }}">{{ presence }}</span>

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -1,0 +1,80 @@
+{% extends "base.html" %}
+{% block title %}françoise{% endblock %}
+{% block shell %}
+{#
+  Public landing: a sequence of full-bleed magazine-cover panels in the
+  Holiday spirit. Scroll flips through "issues". Each cover varies its accent
+  (teal, coral, ochre, navy), carries the françoise masthead as a recurring
+  nameplate, a big Fraunces headline, Courier-Prime cover-lines in a corner,
+  and a postal motif (stamp / postmark / par-avion).
+
+  PLACEHOLDER CONTENT — destinations, personas, and cover-lines below are
+  stand-ins for the owner to replace with real copy. No permanent tagline.
+#}
+<div class="covers">
+
+  {# --- Cover 1 · teal · PLACEHOLDER destination --- #}
+  <section class="cover cover--teal">
+    <div class="cover__plate">
+      <span class="masthead cover__nameplate">françoise</span>
+      <span class="cover__issue t-postmark">Issue Nº 01 · Placeholder</span>
+    </div>
+    <div class="cover__stamp stamp">Par&nbsp;Avion</div>
+    <h2 class="cover__headline">A friend who writes<br>to you from&nbsp;abroad</h2>
+    <ul class="cover__lines t-postmark">
+      <li>[placeholder] your pen-pal in Lisbon</li>
+      <li>[placeholder] letters, not lessons</li>
+      <li>[placeholder] the slow way to fluency</li>
+    </ul>
+  </section>
+
+  {# --- Cover 2 · coral · PLACEHOLDER persona --- #}
+  <section class="cover cover--coral">
+    <div class="cover__plate">
+      <span class="masthead cover__nameplate">françoise</span>
+      <span class="cover__issue t-postmark">Issue Nº 02 · Placeholder</span>
+    </div>
+    <div class="cover__stamp stamp">Postmark</div>
+    <h2 class="cover__headline">Meet [Persona],<br>writing from&nbsp;[City]</h2>
+    <ul class="cover__lines t-postmark">
+      <li>[placeholder] speaks French · A1–C2</li>
+      <li>[placeholder] loves markets & old films</li>
+      <li>[placeholder] replies when she's awake</li>
+    </ul>
+  </section>
+
+  {# --- Cover 3 · ochre · PLACEHOLDER destination --- #}
+  <section class="cover cover--ochre">
+    <div class="cover__plate">
+      <span class="masthead cover__nameplate">françoise</span>
+      <span class="cover__issue t-postmark">Issue Nº 03 · Placeholder</span>
+    </div>
+    <div class="cover__stamp stamp">Air&nbsp;Mail</div>
+    <h2 class="cover__headline">Postcards from<br>somewhere&nbsp;new</h2>
+    <ul class="cover__lines t-postmark">
+      <li>[placeholder] a new city each issue</li>
+      <li>[placeholder] write back at your pace</li>
+      <li>[placeholder] keep every letter</li>
+    </ul>
+  </section>
+
+  {# --- Cover 4 · navy · CTA cover --- #}
+  <section class="cover cover--navy">
+    <div class="cover__plate">
+      <span class="masthead cover__nameplate">françoise</span>
+      <span class="cover__issue t-postmark">Issue Nº 04 · Subscribe</span>
+    </div>
+    <div class="cover__stamp stamp">Reply&nbsp;Paid</div>
+    <h2 class="cover__headline">Start writing<br>today</h2>
+    <div class="cover__cta">
+      {% if logged_in %}
+      <a class="button buttonAccent" href="/app">Open françoise</a>
+      {% else %}
+      <a class="button buttonAccent" href="/signup">Sign up</a>
+      <a class="button buttonSecondary" href="/login">Log in</a>
+      {% endif %}
+    </div>
+  </section>
+
+</div>
+{% endblock %}

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -1,72 +1,242 @@
 {% extends "base.html" %}
 {% block title %}françoise{% endblock %}
+{% block head %}
+<link rel="stylesheet" href="/static/landing.css">
+<link href="https://fonts.googleapis.com/css2?family=Caveat:wght@600&display=swap" rel="stylesheet">
+{% endblock %}
 {% block shell %}
 {#
-  Public landing: a sequence of full-bleed magazine-cover panels in the
-  Holiday spirit. Scroll flips through "issues". Each cover varies its accent
-  (teal, coral, ochre, navy), carries the françoise masthead as a recurring
-  nameplate, a big Fraunces headline, Courier-Prime cover-lines in a corner,
-  and a postal motif (stamp / postmark / par-avion).
-
-  PLACEHOLDER CONTENT — destinations, personas, and cover-lines below are
-  stand-ins for the owner to replace with real copy. No permanent tagline.
+  Public landing as a magazine "desk collage": rotated, overlapping items on the
+  oyster desk, SVG illustration (not stock photos), and transitional beats
+  (par-avion ribbon, stamp filmstrip, torn divider) between sections.
+  PLACEHOLDER copy throughout — swap for real destinations/cover-lines later.
 #}
-<div class="covers">
+<div class="lp">
 
-  {# --- Cover 1 · teal · PLACEHOLDER destination --- #}
-  <section class="cover cover--teal">
-    <div class="cover__plate">
-      <span class="masthead cover__nameplate">françoise</span>
-      <span class="cover__issue t-postmark">Issue Nº 01 · Placeholder</span>
+  <!-- ============ HERO · the desk ============ -->
+  <section class="lp-hero">
+    <div class="desk">
+
+      <div class="desk__item i-roundel" aria-hidden="true"><div class="roundel"></div></div>
+      <div class="desk__item i-roundel-2" aria-hidden="true"><div class="roundel"></div></div>
+
+      <div class="desk__bg" aria-hidden="true">
+        <svg class="routes" viewBox="0 0 1080 640" preserveAspectRatio="xMidYMid slice" xmlns="http://www.w3.org/2000/svg">
+          <path d="M-40 150 C 260 30, 760 250, 1120 110" fill="none" stroke="#234A6B" stroke-width="2" stroke-dasharray="3 9" opacity=".4"/>
+          <path d="M-40 480 C 320 570, 720 330, 1120 500" fill="none" stroke="#C8452E" stroke-width="2" stroke-dasharray="3 9" opacity=".3"/>
+          <circle cx="120" cy="112" r="4" fill="#234A6B" opacity=".5"/>
+          <circle cx="958" cy="150" r="4" fill="#234A6B" opacity=".5"/>
+          <circle cx="150" cy="527" r="4" fill="#C8452E" opacity=".45"/>
+          <circle cx="900" cy="470" r="4" fill="#C8452E" opacity=".4"/>
+        </svg>
+      </div>
+
+      <div class="desk__item i-plane-2" aria-hidden="true">
+        <svg viewBox="0 0 90 60" width="72" height="48" xmlns="http://www.w3.org/2000/svg">
+          <path d="M4 18 L86 6 L44 32 Z" fill="#234A6B"/><path d="M44 32 L86 6 L52 54 Z" fill="#23201C"/>
+        </svg>
+      </div>
+      <div class="desk__item i-plane-3" aria-hidden="true">
+        <svg viewBox="0 0 90 60" width="56" height="38" xmlns="http://www.w3.org/2000/svg">
+          <path d="M4 18 L86 6 L44 32 Z" fill="#C8452E"/><path d="M44 32 L86 6 L52 54 Z" fill="#234A6B"/>
+        </svg>
+      </div>
+      <div class="desk__item i-plane-4" aria-hidden="true">
+        <svg viewBox="0 0 90 60" width="48" height="32" xmlns="http://www.w3.org/2000/svg">
+          <path d="M4 18 L86 6 L44 32 Z" fill="#5C7A3D"/><path d="M44 32 L86 6 L52 54 Z" fill="#23201C"/>
+        </svg>
+      </div>
+      <div class="desk__item i-dots" aria-hidden="true">
+        <svg viewBox="0 0 90 54" width="84" xmlns="http://www.w3.org/2000/svg"><g fill="#0E7C7B">
+          <circle cx="8" cy="8" r="3"/><circle cx="26" cy="8" r="3"/><circle cx="44" cy="8" r="3"/><circle cx="62" cy="8" r="3"/><circle cx="80" cy="8" r="3"/>
+          <circle cx="8" cy="27" r="3"/><circle cx="26" cy="27" r="3"/><circle cx="44" cy="27" r="3"/><circle cx="62" cy="27" r="3"/><circle cx="80" cy="27" r="3"/>
+          <circle cx="8" cy="46" r="3"/><circle cx="26" cy="46" r="3"/><circle cx="44" cy="46" r="3"/><circle cx="62" cy="46" r="3"/><circle cx="80" cy="46" r="3"/>
+        </g></svg>
+      </div>
+      <div class="desk__item i-star" aria-hidden="true">
+        <svg viewBox="0 0 40 40" width="30" height="30" xmlns="http://www.w3.org/2000/svg">
+          <path d="M20 2 L24 16 L38 20 L24 24 L20 38 L16 24 L2 20 L16 16 Z" fill="#E0A63C"/>
+        </svg>
+      </div>
+
+      <div class="desk__item i-sun" aria-hidden="true">
+        <svg viewBox="0 0 160 160" width="150" height="150" xmlns="http://www.w3.org/2000/svg">
+          <g stroke="#E0A63C" stroke-width="4" stroke-linecap="round">
+            <line x1="80" y1="6" x2="80" y2="26"/><line x1="80" y1="134" x2="80" y2="154"/>
+            <line x1="6" y1="80" x2="26" y2="80"/><line x1="134" y1="80" x2="154" y2="80"/>
+            <line x1="27" y1="27" x2="41" y2="41"/><line x1="119" y1="119" x2="133" y2="133"/>
+            <line x1="133" y1="27" x2="119" y2="41"/><line x1="41" y1="119" x2="27" y2="133"/>
+          </g>
+          <circle cx="80" cy="80" r="34" fill="#E0A63C"/>
+        </svg>
+      </div>
+
+      <article class="hero-cover">
+        <div class="cover-issue"><span>Issue Nº 01</span><span>Placeholder</span></div>
+        <div class="cover-name">françoise</div>
+        <h1 class="cover-head">A friend who writes to you from&nbsp;abroad.</h1>
+        <ul class="cover-lines">
+          <li>[placeholder] your pen-pal, at your level</li>
+          <li>[placeholder] letters, not lessons</li>
+          <li>[placeholder] the slow way to fluency</li>
+        </ul>
+      </article>
+
+      <div class="desk__item i-photo">
+        <div class="photo">
+          <svg viewBox="0 0 200 150" xmlns="http://www.w3.org/2000/svg">
+            <rect width="200" height="150" fill="#E0A63C"/>
+            <circle cx="154" cy="40" r="18" fill="#F3EEE3"/>
+            <path d="M55 122 L100 34 L145 122 Z" fill="#234A6B"/>
+            <rect x="94" y="60" width="12" height="20" fill="#23201C"/>
+            <path d="M100 44 L95 60 L105 60 Z" fill="#23201C"/>
+            <rect y="120" width="200" height="30" fill="#0E7C7B"/>
+            <path d="M0 130 q12 -7 24 0 t24 0 t24 0 t24 0 t24 0 t24 0 t24 0 t24 0" stroke="#F3EEE3" stroke-width="1.5" fill="none" opacity=".6"/>
+          </svg>
+          <div class="photo__cap">Normandie</div>
+        </div>
+      </div>
+
+      <div class="desk__item i-photo-2">
+        <div class="photo photo--sm">
+          <svg viewBox="0 0 200 150" xmlns="http://www.w3.org/2000/svg">
+            <rect width="200" height="150" fill="#EDEBE4"/>
+            <circle cx="40" cy="40" r="16" fill="#E0A63C"/>
+            <rect y="96" width="200" height="54" fill="#0E7C7B"/>
+            <path d="M100 30 L100 96 L142 96 Z" fill="#E2603F"/>
+            <path d="M100 40 L100 96 L70 96 Z" fill="#F3EEE3"/>
+            <path d="M64 96 L138 96 L126 108 L76 108 Z" fill="#234A6B"/>
+            <path d="M0 106 q12 -6 24 0 t24 0 t24 0 t24 0 t24 0 t24 0 t24 0 t24 0" stroke="#F3EEE3" stroke-width="1.5" fill="none" opacity=".5"/>
+          </svg>
+          <div class="photo__cap">à la mer</div>
+        </div>
+      </div>
+
+      <div class="desk__item i-photo-3">
+        <div class="photo photo--sm">
+          <svg viewBox="0 0 200 150" xmlns="http://www.w3.org/2000/svg">
+            <rect width="200" height="150" fill="#E0A63C"/>
+            <circle cx="158" cy="38" r="15" fill="#F3EEE3"/>
+            <path d="M0 150 L0 92 Q60 66 120 96 T200 90 L200 150 Z" fill="#5C7A3D"/>
+            <path d="M148 108 q5 -26 10 0 Z" fill="#23201C"/>
+            <path d="M0 150 L0 120 Q90 102 200 122 L200 150 Z" fill="#234A6B"/>
+          </svg>
+          <div class="photo__cap">Toscana</div>
+        </div>
+      </div>
+
+      <div class="desk__item i-ticket-2">
+        <div class="ticket ticket--coral">
+          <div class="ticket__stub">Depart</div>
+          <div class="ticket__body">FROM &nbsp;home<br><b>TO Bologna</b><br>issue Nº 02 · A2</div>
+        </div>
+      </div>
+
+      <div class="desk__item i-postmark">
+        <div class="postmark">Par&nbsp;Avion<br>Nº 01</div>
+      </div>
+
+      <div class="desk__item i-ticket">
+        <div class="ticket">
+          <div class="ticket__stub">Boarding</div>
+          <div class="ticket__body">FROM &nbsp;you<br><b>TO fluency</b><br>seat A1 · gate&nbsp;B1</div>
+        </div>
+      </div>
+
+      <div class="desk__item i-note-1">
+        <div class="note">bonjour&nbsp;!</div>
+      </div>
+
+      <div class="desk__item i-plane" aria-hidden="true">
+        <svg viewBox="0 0 110 70" width="100" height="64" xmlns="http://www.w3.org/2000/svg">
+          <path d="M4 22 L106 8 L54 40 Z" fill="#234A6B"/>
+          <path d="M54 40 L106 8 L66 66 Z" fill="#23201C"/>
+          <path d="M54 40 L66 66 L50 50 Z" fill="#0E7C7B"/>
+          <path d="M2 34 q14 4 26 2" stroke="#C8452E" stroke-width="2" stroke-dasharray="3 5" fill="none"/>
+        </svg>
+      </div>
+
     </div>
-    <div class="cover__stamp stamp">Par&nbsp;Avion</div>
-    <h2 class="cover__headline">A friend who writes<br>to you from&nbsp;abroad</h2>
-    <ul class="cover__lines t-postmark">
-      <li>[placeholder] your pen-pal in Lisbon</li>
-      <li>[placeholder] letters, not lessons</li>
-      <li>[placeholder] the slow way to fluency</li>
-    </ul>
   </section>
 
-  {# --- Cover 2 · coral · PLACEHOLDER persona --- #}
-  <section class="cover cover--coral">
-    <div class="cover__plate">
-      <span class="masthead cover__nameplate">françoise</span>
-      <span class="cover__issue t-postmark">Issue Nº 02 · Placeholder</span>
-    </div>
-    <div class="cover__stamp stamp">Postmark</div>
-    <h2 class="cover__headline">Meet [Persona],<br>writing from&nbsp;[City]</h2>
-    <ul class="cover__lines t-postmark">
-      <li>[placeholder] speaks French · A1–C2</li>
-      <li>[placeholder] loves markets & old films</li>
-      <li>[placeholder] replies when she's awake</li>
-    </ul>
-  </section>
+  <!-- transition: airmail ribbon -->
+  <div class="ribbon-avion" aria-hidden="true">par avion · par avion · par avion · par avion · par avion · par avion · par avion · par avion</div>
 
-  {# --- Cover 3 · ochre · PLACEHOLDER destination --- #}
-  <section class="cover cover--ochre">
-    <div class="cover__plate">
-      <span class="masthead cover__nameplate">françoise</span>
-      <span class="cover__issue t-postmark">Issue Nº 03 · Placeholder</span>
+  <!-- ============ DISPATCHES · how it works ============ -->
+  <div class="lp-deck">
+    <div class="kicker t-postmark">The idea · placeholder</div>
+    <h2>Letters, not lessons</h2>
+  </div>
+  <div class="scatter">
+    <div class="pc">
+      <div class="pc__stamp"><svg viewBox="0 0 60 40"><rect width="60" height="40" fill="#0E7C7B"/><path d="M8 30 L30 12 L52 30 Z" fill="#F3EEE3"/><circle cx="30" cy="14" r="4" fill="#E0A63C"/></svg></div>
+      <div class="pc__place">Step Nº 01</div>
+      <div class="pc__name">Choose a friend</div>
+      <p class="pc__note">[placeholder] Pick a pen-pal abroad and the level you read at, A1 to&nbsp;C2.</p>
     </div>
-    <div class="cover__stamp stamp">Air&nbsp;Mail</div>
-    <h2 class="cover__headline">Postcards from<br>somewhere&nbsp;new</h2>
-    <ul class="cover__lines t-postmark">
-      <li>[placeholder] a new city each issue</li>
-      <li>[placeholder] write back at your pace</li>
-      <li>[placeholder] keep every letter</li>
-    </ul>
-  </section>
+    <div class="pc">
+      <div class="pc__stamp"><svg viewBox="0 0 60 40"><rect width="60" height="40" fill="#E2603F"/><path d="M10 28 L46 16 L54 19 L48 22 L40 22 L32 32 L28 32 L32 22 L20 26 Z" fill="#F3EEE3"/></svg></div>
+      <div class="pc__place">Step Nº 02</div>
+      <div class="pc__name">Write a letter</div>
+      <p class="pc__note">[placeholder] Say hello, ask about their day, tell them about&nbsp;yours.</p>
+    </div>
+    <div class="pc">
+      <div class="pc__stamp"><svg viewBox="0 0 60 40"><rect width="60" height="40" fill="#234A6B"/><rect x="14" y="12" width="32" height="20" fill="#F3EEE3"/><path d="M14 12 L30 24 L46 12" stroke="#234A6B" stroke-width="2.5" fill="none"/></svg></div>
+      <div class="pc__place">Step Nº 03</div>
+      <div class="pc__name">They write back</div>
+      <p class="pc__note">[placeholder] In their own time, in their own voice — and you keep every&nbsp;letter.</p>
+    </div>
+  </div>
 
-  {# --- Cover 4 · navy · CTA cover --- #}
-  <section class="cover cover--navy">
-    <div class="cover__plate">
-      <span class="masthead cover__nameplate">françoise</span>
-      <span class="cover__issue t-postmark">Issue Nº 04 · Subscribe</span>
+  <!-- transition: a strip of stamps -->
+  <div class="stamps-strip" aria-hidden="true">
+    <div class="stamp-il" style="--r:-4deg"><svg viewBox="0 0 100 62"><rect width="100" height="62" fill="#E0A63C"/><circle cx="50" cy="31" r="16" fill="#F3EEE3"/></svg><span>Ochre · 01</span></div>
+    <div class="stamp-il" style="--r:3deg"><svg viewBox="0 0 100 62"><rect width="100" height="62" fill="#0E7C7B"/><path d="M20 44 L50 20 L80 44 Z" fill="#F3EEE3"/></svg><span>Teal · 02</span></div>
+    <div class="stamp-il" style="--r:-2deg"><svg viewBox="0 0 100 62"><rect width="100" height="62" fill="#E2603F"/><circle cx="50" cy="31" r="18" fill="none" stroke="#F3EEE3" stroke-width="3"/><line x1="32" y1="31" x2="68" y2="31" stroke="#F3EEE3" stroke-width="3"/></svg><span>Coral · 03</span></div>
+    <div class="stamp-il" style="--r:4deg"><svg viewBox="0 0 100 62"><rect width="100" height="62" fill="#234A6B"/><path d="M20 46 Q50 16 80 46" fill="none" stroke="#F3EEE3" stroke-width="3"/></svg><span>Navy · 04</span></div>
+    <div class="stamp-il" style="--r:-3deg"><svg viewBox="0 0 100 62"><rect width="100" height="62" fill="#5C7A3D"/><rect x="30" y="18" width="40" height="26" fill="none" stroke="#F3EEE3" stroke-width="3"/></svg><span>Olive · 05</span></div>
+  </div>
+
+  <!-- ============ FRIENDS · pick a pen-pal ============ -->
+  <div class="lp-deck">
+    <div class="kicker t-postmark">Your friends abroad · placeholder</div>
+    <h2>Pick a pen-pal</h2>
+  </div>
+  <div class="scatter">
+    <div class="pc">
+      <div class="pc__stamp"><svg viewBox="0 0 60 40"><rect width="60" height="40" fill="#0E7C7B"/><path d="M20 30 L30 16 L40 30 Z" fill="#234A6B"/><rect y="30" width="60" height="10" fill="#F3EEE3" opacity=".5"/></svg></div>
+      <div class="pc__place">Normandy · France</div>
+      <div class="pc__name">Françoise</div>
+      <p class="pc__note">[placeholder] “The storms all week kept me off the beach — and&nbsp;you?”</p>
+      <span class="pc__level">French · B1</span>
     </div>
-    <div class="cover__stamp stamp">Reply&nbsp;Paid</div>
-    <h2 class="cover__headline">Start writing<br>today</h2>
-    <div class="cover__cta">
+    <div class="pc">
+      <div class="pc__stamp"><svg viewBox="0 0 60 40"><rect width="60" height="40" fill="#E2603F"/><rect x="18" y="14" width="24" height="18" fill="#F3EEE3"/><rect x="26" y="8" width="8" height="8" fill="#F3EEE3"/></svg></div>
+      <div class="pc__place">Bologna · Italy</div>
+      <div class="pc__name">Emilio</div>
+      <p class="pc__note">[placeholder] “Ho mangiato le tagliatelle. Raccontami la tua&nbsp;giornata!”</p>
+      <span class="pc__level">Italian · A2</span>
+    </div>
+    <div class="pc">
+      <div class="pc__stamp"><svg viewBox="0 0 60 40"><rect width="60" height="40" fill="#E0A63C"/><circle cx="30" cy="20" r="10" fill="#C8452E"/></svg></div>
+      <div class="pc__place">Kyoto · Japan</div>
+      <div class="pc__name">Haruko</div>
+      <p class="pc__note">[placeholder] “今日は祭りがありました。あなたの町はどう？”</p>
+      <span class="pc__level">Japanese · A1</span>
+    </div>
+  </div>
+
+  <!-- transition: torn paper -->
+  <svg class="divider-torn" viewBox="0 0 1200 46" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <path d="M0,12 C150,42 300,2 450,22 C600,40 760,6 900,24 C1050,40 1150,12 1200,20 L1200,46 L0,46 Z" fill="#234A6B"/>
+  </svg>
+
+  <!-- ============ CTA ============ -->
+  <section class="lp-cta">
+    <div class="cover-issue kicker t-postmark">Reply paid · placeholder</div>
+    <div class="cover-name">françoise</div>
+    <h2>Start writing today.</h2>
+    <div class="actions">
       {% if logged_in %}
       <a class="button buttonAccent" href="/app">Open françoise</a>
       {% else %}

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -44,7 +44,7 @@ class TestChatUI(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_dashboard_lists_conversations(self):
-        response = self.client.get('/')
+        response = self.client.get('/app')
         self.assertEqual(response.status_code, 200)
         self.assertIn('href="/c/1"', response.text)
         self.assertIn('Boku', response.text)
@@ -75,7 +75,7 @@ class TestChatUI(unittest.TestCase):
 
     def test_routes_require_session(self):
         anon = TestClient(self.app)
-        for path in ('/', '/c/1'):
+        for path in ('/app', '/c/1'):
             response = anon.get(path, follow_redirects=False)
             self.assertEqual(response.status_code, 307)
             self.assertEqual(response.headers['location'], '/login')

--- a/tests/test_landing.py
+++ b/tests/test_landing.py
@@ -29,12 +29,12 @@ class TestLanding(unittest.TestCase):
         os.remove(self.db_path)
 
     def test_anonymous_landing_renders_without_redirect(self):
-        # Anonymous GET / is the public cover-series landing: 200, no redirect,
-        # masthead nameplate present, sign-up CTA shown.
+        # Anonymous GET / is the public landing collage: 200, no redirect,
+        # françoise nameplate present, sign-up CTA shown.
         anon = TestClient(self.app)
         response = anon.get('/', follow_redirects=False)
         self.assertEqual(response.status_code, 200)
-        self.assertIn('masthead', response.text)
+        self.assertIn('cover-name', response.text)
         self.assertIn('françoise', response.text)
         self.assertIn('cover', response.text)
         self.assertIn('href="/signup"', response.text)

--- a/tests/test_landing.py
+++ b/tests/test_landing.py
@@ -1,0 +1,59 @@
+import os
+import tempfile
+import unittest
+
+from argon2 import PasswordHasher
+from fastapi.testclient import TestClient
+
+from françoise.app import App
+from françoise.db import open_db
+from françoise.migrate import upgrade_to_head
+
+
+class TestLanding(unittest.TestCase):
+    def setUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix='.db')
+        os.close(fd)
+
+        upgrade_to_head(self.db_path)
+        password_hash = PasswordHasher().hash('correct horse')
+        with open_db(self.db_path) as db:
+            account = db.create_account('Acme')
+        with open_db(self.db_path, account_id=account[0]) as db:
+            db.create_user('Alice', 'alice@example.com', password_hash)
+
+        self.app = App(DATABASE_URL=self.db_path)
+        self.client = TestClient(self.app)
+
+    def tearDown(self):
+        os.remove(self.db_path)
+
+    def test_anonymous_landing_renders_without_redirect(self):
+        # Anonymous GET / is the public cover-series landing: 200, no redirect,
+        # masthead nameplate present, sign-up CTA shown.
+        anon = TestClient(self.app)
+        response = anon.get('/', follow_redirects=False)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('masthead', response.text)
+        self.assertIn('françoise', response.text)
+        self.assertIn('cover', response.text)
+        self.assertIn('href="/signup"', response.text)
+
+    def test_dashboard_redirects_anonymous_to_login(self):
+        anon = TestClient(self.app)
+        response = anon.get('/app', follow_redirects=False)
+        self.assertEqual(response.status_code, 307)
+        self.assertEqual(response.headers['location'], '/login')
+
+    def test_logged_in_landing_links_into_app(self):
+        self.client.post('/login', data={
+            'email': 'alice@example.com',
+            'password': 'correct horse'})
+        response = self.client.get('/', follow_redirects=False)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('href="/app"', response.text)
+        self.assertNotIn('href="/signup"', response.text)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -59,8 +59,8 @@ class TestLoginRoutes(unittest.TestCase):
         self.assertEqual(row[0], 1)
 
     def test_login_sets_session_cookie_and_guards_page(self):
-        # No cookie redirects to /login.
-        response = self.client.get('/', follow_redirects=False)
+        # No cookie redirects the dashboard to /login.
+        response = self.client.get('/app', follow_redirects=False)
         self.assertEqual(response.status_code, 307)
         self.assertEqual(response.headers['location'], '/login')
 
@@ -71,8 +71,8 @@ class TestLoginRoutes(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn('session', self.client.cookies)
 
-        # A request carrying the cookie reaches the page.
-        response = self.client.get('/', follow_redirects=False)
+        # A request carrying the cookie reaches the dashboard.
+        response = self.client.get('/app', follow_redirects=False)
         self.assertEqual(response.status_code, 200)
 
     def test_wrong_password_shows_error(self):


### PR DESCRIPTION
Closes #126.

## What

- **`GET /` → public landing (no auth).** A vertical sequence of four full-bleed magazine-cover panels in the _Holiday_ spirit, one accent per cover (teal, coral, ochre, navy). Each carries the **françoise** nameplate as a recurring masthead, a big Fraunces cover headline, Courier-Prime cover-lines in a corner, and a stamp / par-avion motif. Scrolling flips through the "issues"; the final cover holds the CTAs. Anonymous visitors see **Sign up / Log in**; a logged-in visitor gets **Open françoise** instead.
- **Placeholder content.** Destinations, personas, and cover-lines are clearly marked (`[placeholder]`, `Nº · Placeholder`, template comments) for the owner to swap in real copy later. No permanent tagline invented.
- **Dashboard moved to `GET /app`.** `require_session` still redirects anonymous access to `/login`; back-links in `chat.html` / `account_settings.html` now point at `/app`.
- **Design system.** Landing overrides `base.html` `{% block shell %}` to go full-bleed; new cover CSS is built on the existing tokens/classes in `app.css`, responsive (`clamp()`), minimal htmx, no custom JS.

## Validation

- `uv sync` — OK
- `uv run python -m unittest discover -s tests` — **135 tests, OK** (updated tests that assumed `/` == dashboard; added `test_landing.py`: anonymous `GET /` → 200 landing with masthead + no redirect, `GET /app` anonymous → 307 `/login`, logged-in landing links into `/app`)
- `uv run python -m scripts.provision --database /tmp/p126.db --reset` — OK

Note: per task instructions this was validated via unittest + TestClient only (no browser / Chrome DevTools).