### PR TITLE
Restyle authed surfaces onto the design system (#127)

### DIFF
--- a/design.md
+++ b/design.md
@@ -66,6 +66,12 @@ typography:
     fontWeight: 700
     lineHeight: 1.2
     letterSpacing: "0.08em"
+  annotation:
+    fontFamily: "Caveat"
+    fontSize: "20px"
+    fontWeight: 600
+    lineHeight: 1.2
+    letterSpacing: "0"
 rounded:
   none: "0"
   sm: "2px"
@@ -168,6 +174,9 @@ An editorial pairing across three roles:
 - **Courier Prime** (typewriter) for the **postmark** role — stamps, dates,
   CEFR badges, cancellation marks. Uppercase, tracked out; used sparingly for
   correspondence flavor.
+- **Caveat** (handwriting) for the **annotation** role — a friend's hand: notes
+  scribbled in a margin, a "bonjour !" on a postcard. Used sparingly for warmth;
+  never for controls or running text.
 
 Rules: display type is tight (negative tracking) and big; body type is roomy
 (1.6 line-height). Never set body in the display face, and never stretch the

--- a/françoise/app.py
+++ b/françoise/app.py
@@ -36,20 +36,6 @@ from .presence import is_free, presence_label, presence_local_time
 
 TEMPLATES = Jinja2Templates(directory='templates')
 
-SIGNUP_FORM = """<!DOCTYPE html>
-<html lang="en">
-<body>
-    <form method="post" action="/signup">
-        <input type="text" name="name" required>
-        <input type="email" name="email" required>
-        <input type="password" name="password" required>
-        <label><input type="checkbox" name="over_18" value="yes"> I am 18 or older</label>
-        <button type="submit">Sign up</button>
-    </form>
-</body>
-</html>
-"""
-
 
 def reply_fragment(conversation_id: int, message: str) -> str:
     # OOB fragment that appends a reply to an open conversation's messages.
@@ -215,8 +201,8 @@ def App(**kwargs):
         return 'Logged in.'
 
     @app.get('/signup', response_class=HTMLResponse)
-    def signup_form() -> str:
-        return SIGNUP_FORM
+    def signup_form(request: Request):
+        return TEMPLATES.TemplateResponse(request, 'signup.html')
 
     @app.post('/signup', response_class=HTMLResponse)
     def signup(

--- a/static/app.css
+++ b/static/app.css
@@ -65,6 +65,11 @@ body::before {
   padding: var(--space-xxl) var(--space-xl) var(--space-xxxl);
 }
 
+/* Breathing room off the masthead on app surfaces. */
+.wrap header { margin-bottom: var(--space-lg); }
+.wrap header .masthead { line-height: 1.1; }
+.wrap header .rule { margin: var(--space-sm) 0 var(--space-md); }
+
 /* Masthead / nameplate — Fraunces at masthead scale over a rule. */
 .masthead {
   font-family: "Fraunces", serif;

--- a/static/app.css
+++ b/static/app.css
@@ -298,6 +298,122 @@ label {
 .cover--navy .buttonSecondary { color: var(--paper); border-color: var(--paper); }
 .cover--navy .buttonSecondary:hover { box-shadow: 4px 4px 0 var(--paper); }
 
+/* Authed nav — a simple tracked-caption row of links under the masthead. */
+.appnav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-lg);
+  margin-top: var(--space-sm);
+}
+.appnav a {
+  font-family: "Work Sans", sans-serif;
+  font-weight: 500;
+  font-size: 13px;
+  letter-spacing: .02em;
+  text-transform: uppercase;
+  color: var(--ink);
+  text-decoration: none;
+  border-bottom: 2px solid transparent;
+  padding-bottom: 2px;
+}
+.appnav a:hover { border-bottom-color: var(--coral); }
+
+/* Page head — a display title with a Courier kicker over it. */
+.page-head { margin-bottom: var(--space-xl); }
+.page-head .kicker { margin-bottom: var(--space-xs); }
+.page-head h1 { margin: 0; }
+
+/* Age-gate framed on-brand for the signup card. */
+.check-frame {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  margin-top: var(--space-md);
+  padding: var(--space-md);
+  background: var(--paper);
+  border: 1px dashed var(--vermilion);
+  font-family: "Work Sans", sans-serif;
+  font-size: 14px;
+}
+.check-frame input { width: auto; box-shadow: none; }
+
+/* Correspondence deck — conversations/personas as postcards in a wide grid. */
+.deck {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: var(--space-lg);
+}
+.card-link { text-decoration: none; color: inherit; display: block; }
+.card-link:hover .postcard { box-shadow: 4px 4px 0 var(--navy); }
+
+.postcard__head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-md);
+}
+.postcard__name {
+  font-family: "Fraunces", serif;
+  font-weight: 600;
+  font-size: 24px;
+  line-height: 1.15;
+  margin: 0;
+}
+.postcard__meta {
+  margin-top: var(--space-sm);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  align-items: center;
+}
+.postcard__note {
+  margin: var(--space-md) 0 0;
+  color: var(--inkMuted);
+  font-size: 14px;
+}
+
+/* Empty state — a par-avion note inviting the first correspondence. */
+.empty {
+  text-align: center;
+  padding: var(--space-xxl) var(--space-xl);
+}
+.empty h2 { font-family: "Fraunces", serif; font-weight: 600; margin: 0 0 var(--space-sm); }
+.empty p { color: var(--inkMuted); margin: 0 0 var(--space-lg); }
+
+/* Handwritten annotation — a friend's hand (Caveat). */
+.annotation {
+  font-family: "Caveat", cursive;
+  font-weight: 600;
+  font-size: 20px;
+  color: var(--teal);
+}
+
+/* Editorial "passport / persona" form — a framed field grid. */
+.passport {
+  background: var(--paperShade);
+  border: 1px solid var(--rule);
+  border-top: 3px solid var(--teal);
+  padding: var(--space-xl);
+  max-width: 720px;
+}
+.passport .field { max-width: none; margin-top: var(--space-lg); }
+.form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0 var(--space-lg);
+}
+.form-grid .field-wide { grid-column: 1 / -1; }
+@media (max-width: 560px) { .form-grid { grid-template-columns: 1fr; } }
+
+.error {
+  color: var(--vermilion);
+  font-family: "Courier Prime", monospace;
+  font-weight: 700;
+  font-size: 13px;
+  letter-spacing: .04em;
+  margin: 0 0 var(--space-md);
+}
+
 /* Par avion border — red/blue dashed airmail frame for correspondence cards. */
 .avion {
   padding: 20px 24px;

--- a/templates/_appnav.html
+++ b/templates/_appnav.html
@@ -1,0 +1,6 @@
+<nav class="appnav">
+    <a href="/app">Desk</a>
+    <a href="/agents">Friends</a>
+    <a href="/agents/new">New friend</a>
+    <a href="/settings">Settings</a>
+</nav>

--- a/templates/account_settings.html
+++ b/templates/account_settings.html
@@ -1,19 +1,20 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="utf-8">
-    <title>Account settings</title>
-</head>
-<body>
-    <p><a href="/app">Back</a></p>
-    <h1>Account settings</h1>
-    <form method="post" action="/settings">
-        <label>
-            <input type="checkbox" name="always_available" value="yes"
-                {% if always_available %}checked{% endif %}>
-            Always available (adult personas reply without waiting)
-        </label>
-        <button type="submit">Save</button>
-    </form>
-</body>
-</html>
+{% extends "base.html" %}
+{% block title %}Account settings · françoise{% endblock %}
+{% block nav %}{% include "_appnav.html" %}{% endblock %}
+{% block content %}
+<div class="page-head">
+    <div class="kicker">Your account</div>
+    <h1 class="t-display">Settings</h1>
+</div>
+
+<form method="post" action="/settings" class="passport">
+    <label class="check-frame">
+        <input type="checkbox" name="always_available" value="yes"
+            {% if always_available %}checked{% endif %}>
+        <span>Always available (adult personas reply without waiting)</span>
+    </label>
+    <div class="field">
+        <button type="submit" class="button buttonAccent">Save</button>
+    </div>
+</form>
+{% endblock %}

--- a/templates/agents_list.html
+++ b/templates/agents_list.html
@@ -1,27 +1,37 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="utf-8">
-    <title>Friends</title>
-    <script src="https://unpkg.com/htmx.org@2"></script>
-</head>
-<body>
-    <h1>Friends</h1>
-    <p><a href="/agents/new">Add a friend</a></p>
-    {% if agents %}
-    <ul>
-        {% for agent in agents %}
-        <li>
-            {{ agent.name }} — {{ agent.language }} ({{ agent.proficiency }})
-            {% if agent.location %}— {{ agent.location }}{% endif %}
-            <form method="post" action="/agents/{{ agent.id }}/start">
-                <button type="submit">Start conversation</button>
-            </form>
-        </li>
-        {% endfor %}
-    </ul>
-    {% else %}
-    <p>No friends yet.</p>
-    {% endif %}
-</body>
-</html>
+{% extends "base.html" %}
+{% block title %}Friends · françoise{% endblock %}
+{% block nav %}{% include "_appnav.html" %}{% endblock %}
+{% block content %}
+<div class="page-head">
+    <div class="kicker">Your friends abroad</div>
+    <h1 class="t-display">Friends</h1>
+</div>
+
+{% if agents %}
+<div class="deck">
+    {% for agent in agents %}
+    <div class="postcard">
+        <div class="postcard__head">
+            <h2 class="postcard__name">{{ agent.name }}</h2>
+            <span class="badge level">{{ agent.proficiency }}</span>
+        </div>
+        <div class="postcard__meta">
+            <span class="t-postmark">{{ agent.language }}</span>
+            {% if agent.location %}<span class="t-postmark">· {{ agent.location }}</span>{% endif %}
+        </div>
+        <form method="post" action="/agents/{{ agent.id }}/start">
+            <div class="field">
+                <button type="submit" class="button">Start conversation</button>
+            </div>
+        </form>
+    </div>
+    {% endfor %}
+</div>
+{% else %}
+<div class="empty avion">
+    <h2>No friends yet</h2>
+    <p>Invent a pen-pal abroad to start writing.</p>
+    <a class="button buttonAccent" href="/agents/new">New friend</a>
+</div>
+{% endif %}
+{% endblock %}

--- a/templates/agents_new.html
+++ b/templates/agents_new.html
@@ -1,29 +1,55 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="utf-8">
-    <title>Add a friend</title>
-    <script src="https://unpkg.com/htmx.org@2"></script>
-</head>
-<body>
-    <h1>Add a friend</h1>
-    {% if error %}<p>{{ error }}</p>{% endif %}
-    <form method="post" action="/agents">
-        <label>Name <input type="text" name="name" required></label>
-        <label>Native language <input type="text" name="native_language" required></label>
-        <label>Target language <input type="text" name="language" required></label>
-        <label>Proficiency
-            <select name="proficiency" required>
+{% extends "base.html" %}
+{% block title %}New friend · françoise{% endblock %}
+{% block nav %}{% include "_appnav.html" %}{% endblock %}
+{% block content %}
+<div class="page-head">
+    <div class="kicker">Passport · new persona</div>
+    <h1 class="t-display">A friend abroad</h1>
+</div>
+
+{% if error %}<p class="error">{{ error }}</p>{% endif %}
+
+<form method="post" action="/agents" class="passport">
+    <div class="form-grid">
+        <div class="field">
+            <label for="name">Name</label>
+            <input type="text" id="name" name="name" required>
+        </div>
+        <div class="field">
+            <label for="proficiency">Proficiency</label>
+            <select id="proficiency" name="proficiency" required>
                 {% for level in cefr_levels %}
                 <option value="{{ level }}">{{ level }}</option>
                 {% endfor %}
             </select>
-        </label>
-        <label>Location (lat, long) <input type="text" name="location"></label>
-        <label>Timezone (IANA) <input type="text" name="timezone" placeholder="Europe/Paris"></label>
-        <label>Interests (comma-separated) <input type="text" name="interests"></label>
-        <label>Age <input type="number" name="age" min="0"></label>
-        <button type="submit">Create</button>
-    </form>
-</body>
-</html>
+        </div>
+        <div class="field">
+            <label for="native_language">Native language</label>
+            <input type="text" id="native_language" name="native_language" required>
+        </div>
+        <div class="field">
+            <label for="language">Target language</label>
+            <input type="text" id="language" name="language" required>
+        </div>
+        <div class="field">
+            <label for="location">Location (lat, long)</label>
+            <input type="text" id="location" name="location">
+        </div>
+        <div class="field">
+            <label for="timezone">Timezone (IANA)</label>
+            <input type="text" id="timezone" name="timezone" placeholder="Europe/Paris">
+        </div>
+        <div class="field field-wide">
+            <label for="interests">Interests (comma-separated)</label>
+            <input type="text" id="interests" name="interests">
+        </div>
+        <div class="field">
+            <label for="age">Age</label>
+            <input type="number" id="age" name="age" min="0">
+        </div>
+    </div>
+    <div class="field">
+        <button type="submit" class="button buttonAccent">Create</button>
+    </div>
+</form>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,7 +6,7 @@
     <title>{% block title %}françoise{% endblock %}</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Work+Sans:wght@400;500;600&family=Courier+Prime:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Work+Sans:wght@400;500;600&family=Courier+Prime:wght@400;700&family=Caveat:wght@600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/static/app.css">
     <script src="https://unpkg.com/htmx.org@2"></script>
     {% block head %}{% endblock %}

--- a/templates/chat_list.html
+++ b/templates/chat_list.html
@@ -1,25 +1,34 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="utf-8">
-    <title>Conversations</title>
-    <script src="https://unpkg.com/htmx.org@2"></script>
-</head>
-<body>
-    <h1>Conversations</h1>
-    <p><a href="/agents/new">Add a friend</a> | <a href="/settings">Settings</a></p>
-    {% if conversations %}
-    <ul>
-        {% for conversation in conversations %}
-        <li>
-            <a href="/c/{{ conversation.id }}">{{ conversation.agent_name }}</a>
-            <span id="presence-{{ conversation.id }}">{{ conversation.presence }}</span>
-            <span id="unread-{{ conversation.id }}">0</span>
-        </li>
-        {% endfor %}
-    </ul>
-    {% else %}
-    <p>No conversations yet.</p>
-    {% endif %}
-</body>
-</html>
+{% extends "base.html" %}
+{% block title %}Your desk · françoise{% endblock %}
+{% block nav %}{% include "_appnav.html" %}{% endblock %}
+{% block content %}
+<div class="page-head">
+    <div class="kicker">Your correspondence</div>
+    <h1 class="t-display">The desk</h1>
+</div>
+
+{% if conversations %}
+<div class="deck">
+    {% for conversation in conversations %}
+    <a class="card-link" href="/c/{{ conversation.id }}">
+        <div class="postcard">
+            <div class="postcard__head">
+                <h2 class="postcard__name">{{ conversation.agent_name }}</h2>
+                <span class="badge unread" id="unread-{{ conversation.id }}">0</span>
+            </div>
+            <div class="postcard__meta">
+                <span class="badge presence" id="presence-{{ conversation.id }}">{{ conversation.presence }}</span>
+            </div>
+            <p class="postcard__note">Read the latest letter →</p>
+        </div>
+    </a>
+    {% endfor %}
+</div>
+{% else %}
+<div class="empty avion">
+    <h2>Start a correspondence</h2>
+    <p>No letters yet. Choose a friend abroad and write your first line.</p>
+    <a class="button buttonAccent" href="/agents/new">New friend</a>
+</div>
+{% endif %}
+{% endblock %}

--- a/templates/conversation_settings.html
+++ b/templates/conversation_settings.html
@@ -1,25 +1,34 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="utf-8">
-    <title>Settings — {{ conversation.agent_name }}</title>
-</head>
-<body>
-    <p><a href="/c/{{ conversation.id }}">Back</a></p>
-    <h1>Settings — {{ conversation.agent_name }}</h1>
-    {% if error %}<p>{{ error }}</p>{% endif %}
-    <form method="post" action="/c/{{ conversation.id }}/settings">
-        <label>Proficiency
-            <select name="proficiency" required>
-                {% for level in cefr_levels %}
-                <option value="{{ level }}"{% if level == conversation.user_proficiency %} selected{% endif %}>{{ level }}</option>
-                {% endfor %}
-            </select>
-        </label>
-        <label>Model
-            <input type="text" name="model" value="{{ conversation.model }}" required>
-        </label>
-        <button type="submit">Save</button>
-    </form>
-</body>
-</html>
+{% extends "base.html" %}
+{% block title %}Settings · {{ conversation.agent_name }} · françoise{% endblock %}
+{% block nav %}
+<nav class="appnav">
+    <a href="/c/{{ conversation.id }}">Back to letters</a>
+    <a href="/app">Desk</a>
+</nav>
+{% endblock %}
+{% block content %}
+<div class="page-head">
+    <div class="kicker">Correspondence settings</div>
+    <h1 class="t-display">{{ conversation.agent_name }}</h1>
+</div>
+
+{% if error %}<p class="error">{{ error }}</p>{% endif %}
+
+<form method="post" action="/c/{{ conversation.id }}/settings" class="passport">
+    <div class="field">
+        <label for="proficiency">Proficiency</label>
+        <select id="proficiency" name="proficiency" required>
+            {% for level in cefr_levels %}
+            <option value="{{ level }}"{% if level == conversation.user_proficiency %} selected{% endif %}>{{ level }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="field">
+        <label for="model">Model</label>
+        <input type="text" id="model" name="model" value="{{ conversation.model }}" required>
+    </div>
+    <div class="field">
+        <button type="submit" class="button buttonAccent">Save</button>
+    </div>
+</form>
+{% endblock %}

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+{% block title %}Sign up · françoise{% endblock %}
+{% block shell %}
+<div class="auth">
+    <div class="auth-card">
+        <div class="auth-head">
+            <div class="kicker">Start a correspondence</div>
+            <h1 class="masthead"><a href="/">françoise</a></h1>
+        </div>
+        <hr class="rule">
+        <form method="post" action="/signup">
+            <div class="field">
+                <label for="name">Name</label>
+                <input type="text" id="name" name="name" required>
+            </div>
+            <div class="field">
+                <label for="email">Email</label>
+                <input type="email" id="email" name="email" required>
+            </div>
+            <div class="field">
+                <label for="password">Password</label>
+                <input type="password" id="password" name="password" required>
+            </div>
+            <label class="check-frame">
+                <input type="checkbox" name="over_18" value="yes">
+                <span>I am 18 or older</span>
+            </label>
+            <div class="field">
+                <button type="submit" class="button buttonAccent">Sign up</button>
+            </div>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/tests/test_signup.py
+++ b/tests/test_signup.py
@@ -27,6 +27,16 @@ class TestSignupRoutes(unittest.TestCase):
             return db.connection.execute(
                 'SELECT COUNT(*) FROM users').fetchone()[0]
 
+    def test_get_signup_extends_base_shell(self):
+        # The template extends base.html: masthead nameplate, served CSS,
+        # and keeps the 18+ age-gate checkbox.
+        response = self.client.get('/signup')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('<form', response.text)
+        self.assertIn('class="masthead"', response.text)
+        self.assertIn('/static/app.css', response.text)
+        self.assertIn('name="over_18"', response.text)
+
     def test_over_18_completes_signup(self):
         response = self.client.post('/signup', data={
             'name': 'Alice',


### PR DESCRIPTION
Closes #127.

Visual layer only — every route, behavior, and htmx wiring preserved.

## What changed
- **signup**: inline `SIGNUP_FORM` string → `templates/signup.html` on the centered `.auth-card` layout (matching login); 18+ age gate framed on-brand (dashed vermilion). `POST /signup` unchanged.
- **Dashboard (`/app`, `chat_list.html`)**: conversations as correspondence postcards (persona name, presence stamp, unread badge, link to `/c/{id}`) in a wide editorial deck grid; par-avion empty state ("Start a correspondence") with a clear link to `/agents/new`.
- **Persona create (`agents_new.html`)**: editorial passport/persona form, all fields kept (name, native/target language, proficiency, location, timezone, interests, age).
- **Persona list (`agents_list.html`)**: stamped postcards with CEFR level badge; keeps the start-conversation form.
- **Settings** (`conversation_settings.html`, `account_settings.html`): on-brand passport forms; CEFR + model + always-available toggle unchanged.
- Minimal authed **nav** via `{% block nav %}` (shared `_appnav.html`): Desk / Friends / New friend / Settings.
- **design.md**: added the `Caveat` handwriting font as the annotation role (source of truth); loaded it in `base.html`.

## Validation
- `uv sync` OK
- `uv run python -m unittest discover -s tests` → 136 tests, OK (added a signup GET test asserting the template extends base + keeps the age gate)
- `uv run python -m scripts.provision --database /tmp/p127.db --reset` OK
- Smoke-tested via TestClient: all authed surfaces render with the base shell (masthead + app.css + appnav).
- No browser used.